### PR TITLE
Fix and test for ticket #4964 - assert in debug mode on x64

### DIFF
--- a/include/boost/numeric/interval/detail/msvc_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/msvc_rounding_control.hpp
@@ -88,7 +88,20 @@ struct x86_rounding
   static void get_rounding_mode(rounding_mode& mode)
   { mode = msvc2hard(_control87(0, 0)); }
   static void set_rounding_mode(const rounding_mode mode)
-  { _control87(hard2msvc(mode), _MCW_EM | _MCW_RC | _MCW_PC | _MCW_IC); }
+  {
+    _control87(hard2msvc(mode),
+      _MCW_EM | _MCW_RC
+#if !defined(_M_AMD64) && !defined(_M_ARM)
+      // x64 ignores _MCW_PC and _MCW_IC, and the Debug CRT library actually
+      // asserts when these are passed to _control87.
+      // MSDN says on '_control87' that changing precision (_MCW_PC) or
+      // infinity (_MCW_IC) handling is not supported on the ARM and x64
+      // architectures and that _control87 raises an assertion
+      // and the invalid parameter handler is invoked.
+      | _MCW_PC | _MCW_IC
+#endif
+    );
+  }
   static double to_int(const double& x) { return rint(x); }
 };
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -26,6 +26,7 @@ import testing ;
     [ run libs/numeric/interval/test/add.cpp      ]
     [ run libs/numeric/interval/test/det.cpp      ]
     [ run libs/numeric/interval/test/fmod.cpp     ]
+    [ run libs/numeric/interval/test/msvc_x64_flags.cpp ]
     [ run libs/numeric/interval/test/mul.cpp      ]
     [ run libs/numeric/interval/test/overflow.cpp ]
     [ run libs/numeric/interval/test/pi.cpp       ]

--- a/test/msvc_x64_flags.cpp
+++ b/test/msvc_x64_flags.cpp
@@ -1,0 +1,21 @@
+/* Boost test/msvc_x64_flags.cpp
+ * Test for amd64\ieee.c(102) : Assertion failed: (mask&~(_MCW_DN|_MCW_EM|_MCW_RC))==0.
+ * This happens with MSVC on x64 in Debug mode. See ticket #4964.
+ *
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or
+ * copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#include <boost/numeric/interval.hpp>
+#include <boost/test/minimal.hpp>
+#include "bugs.hpp"
+
+int test_main(int, char *[]) {
+  boost::numeric::interval<double> i(0.0, 0.0);
+  boost::numeric::interval<double> i2 = 60.0 - i;
+# ifdef __BORLANDC__
+  ::detail::ignore_warnings();
+# endif
+  return 0;
+}


### PR DESCRIPTION
This fixes #4964 and adds a testcase which used to trigger the assert.  Note that the testcase only fails on x64 (address-model=64) in debug mode (and when the fix is not in place, obviously).
I haven't had a chance to test this on ARM, but MSDN is clear on that this applies to ARM in the same way so the fix also applies to ARM.
