### PR TITLE
Unused typedef in norm causes compiler warning

### DIFF
--- a/include/boost/numeric/interval/utility.hpp
+++ b/include/boost/numeric/interval/utility.hpp
@@ -248,7 +248,6 @@ bisect(const interval<T, Policies>& x)
 template<class T, class Policies> inline
 T norm(const interval<T, Policies>& x)
 {
-  typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x)) {
     typedef typename Policies::checking checking;
     return checking::nan();


### PR DESCRIPTION
The unused typedef in the body of norm() causes:

/boost/boost/numeric/interval/utility.hpp: In function 'T boost::numeric::norm(const boost::numeric::interval<T, Policies>&)':
/boost/boost/numeric/interval/utility.hpp:251:33: warning: typedef 'I' locally defined but not used [-Wunused-local-typedefs]
   typedef interval<T, Policies> I;
                                 ^