### PR TITLE
Reencoded a few headers that used Windows-1252 with UTF-8.

### DIFF
--- a/examples/filter.cpp
+++ b/examples/filter.cpp
@@ -2,7 +2,7 @@
  * two examples of filters for computing the sign of a determinant
  * the second filter is based on an idea presented in
  * "Interval arithmetic yields efficient dynamic filters for computational
- * geometry" by Brönnimann, Burnikel and Pion, 2001
+ * geometry" by BrÃ¶nnimann, Burnikel and Pion, 2001
  *
  * Copyright 2003 Guillaume Melquiond
  *

--- a/examples/io.cpp
+++ b/examples/io.cpp
@@ -59,7 +59,7 @@ std::basic_ostream<CharType, CharTraits> &operator<<
   if (empty(value)) {
     return stream << "nothing";
   } else {
-    return stream << median(value) << " ± " << width(value) / 2;
+    return stream << median(value) << " Â± " << width(value) / 2;
   }
 }
 

--- a/include/boost/numeric/interval.hpp
+++ b/include/boost/numeric/interval.hpp
@@ -1,7 +1,7 @@
 /* Boost interval.hpp header file
  *
  * Copyright 2000 Jens Maurer
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/arith.hpp
+++ b/include/boost/numeric/interval/arith.hpp
@@ -1,7 +1,7 @@
 /* Boost interval/arith.hpp template implementation file
  *
  * Copyright 2000 Jens Maurer
- * Copyright 2002-2003 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002-2003 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/arith2.hpp
+++ b/include/boost/numeric/interval/arith2.hpp
@@ -4,7 +4,7 @@
  * functions: fmod, sqrt, square, pov, inverse and
  * a multi-interval division.
  *
- * Copyright 2002-2003 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002-2003 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/checking.hpp
+++ b/include/boost/numeric/interval/checking.hpp
@@ -1,6 +1,6 @@
 /* Boost interval/checking.hpp template implementation file
  *
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/compare.hpp
+++ b/include/boost/numeric/interval/compare.hpp
@@ -1,6 +1,6 @@
 /* Boost interval/compare.hpp template implementation file
  *
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/compare/explicit.hpp
+++ b/include/boost/numeric/interval/compare/explicit.hpp
@@ -1,7 +1,7 @@
 /* Boost interval/compare/explicit.hpp template implementation file
  *
  * Copyright 2000 Jens Maurer
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/constants.hpp
+++ b/include/boost/numeric/interval/constants.hpp
@@ -1,6 +1,6 @@
 /* Boost interval/constants.hpp template implementation file
  *
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/detail/alpha_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/alpha_rounding_control.hpp
@@ -1,6 +1,6 @@
 /* Boost interval/detail/alpha_rounding_control.hpp file
  *
- * Copyright 2005 Felix Höfling, Guillaume Melquiond
+ * Copyright 2005 Felix HÃ¶fling, Guillaume Melquiond
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/detail/bcc_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/bcc_rounding_control.hpp
@@ -1,7 +1,7 @@
 /* Boost interval/detail/bcc_rounding_control.hpp file
  *
  * Copyright 2000 Jens Maurer
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/detail/bugs.hpp
+++ b/include/boost/numeric/interval/detail/bugs.hpp
@@ -1,7 +1,7 @@
 /* Boost interval/detail/bugs.hpp file
  *
  * Copyright 2000 Jens Maurer
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/detail/c99_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/c99_rounding_control.hpp
@@ -1,7 +1,7 @@
 /* Boost interval/detail/c99_rounding_control.hpp file
  *
  * Copyright 2000 Jens Maurer
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/detail/c99sub_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/c99sub_rounding_control.hpp
@@ -1,7 +1,7 @@
 /* Boost interval/detail/c99sub_rounding_control.hpp file
  *
  * Copyright 2000 Jens Maurer
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/detail/interval_prototype.hpp
+++ b/include/boost/numeric/interval/detail/interval_prototype.hpp
@@ -1,6 +1,6 @@
 /* Boost interval/detail/interval_prototype.hpp file
  *
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/detail/msvc_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/msvc_rounding_control.hpp
@@ -1,7 +1,7 @@
 /* Boost interval/detail/msvc_rounding_control.hpp file
  *
  * Copyright 2000 Maarten Keijzer
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/detail/ppc_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/ppc_rounding_control.hpp
@@ -1,7 +1,7 @@
 /* Boost interval/detail/ppc_rounding_control.hpp file
  *
  * Copyright 2000 Jens Maurer
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  * Copyright 2005 Guillaume Melquiond
  *
  * Distributed under the Boost Software License, Version 1.0.

--- a/include/boost/numeric/interval/detail/sparc_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/sparc_rounding_control.hpp
@@ -1,7 +1,7 @@
 /* Boost interval/detail/sparc_rounding_control.hpp file
  *
  * Copyright 2000 Jens Maurer
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/detail/test_input.hpp
+++ b/include/boost/numeric/interval/detail/test_input.hpp
@@ -1,6 +1,6 @@
 /* Boost interval/detail/test_input.hpp file
  *
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/detail/x86_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/x86_rounding_control.hpp
@@ -1,7 +1,7 @@
 /* Boost interval/detail/x86_rounding_control.hpp file
  *
  * Copyright 2000 Jens Maurer
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/detail/x86gcc_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/x86gcc_rounding_control.hpp
@@ -1,7 +1,7 @@
 /* Boost interval/detail/x86gcc_rounding_control.hpp file
  *
  * Copyright 2000 Jens Maurer
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/ext/x86_fast_rounding_control.hpp
+++ b/include/boost/numeric/interval/ext/x86_fast_rounding_control.hpp
@@ -7,7 +7,7 @@
  * overflow would happen without it. Indeed, only
  * values in range are correctly rounded.
  *
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/interval.hpp
+++ b/include/boost/numeric/interval/interval.hpp
@@ -1,6 +1,6 @@
 /* Boost interval/interval.hpp header file
  *
- * Copyright 2002-2003 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002-2003 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/limits.hpp
+++ b/include/boost/numeric/interval/limits.hpp
@@ -1,7 +1,7 @@
 /* Boost interval/limits.hpp template implementation file
  *
  * Copyright 2000 Jens Maurer
- * Copyright 2002-2003 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002-2003 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/rounded_arith.hpp
+++ b/include/boost/numeric/interval/rounded_arith.hpp
@@ -1,6 +1,6 @@
 /* Boost interval/rounded_arith.hpp template implementation file
  *
- * Copyright 2002-2003 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002-2003 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/rounded_transc.hpp
+++ b/include/boost/numeric/interval/rounded_transc.hpp
@@ -1,6 +1,6 @@
 /* Boost interval/rounded_transc.hpp template implementation file
  *
- * Copyright 2002-2003 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002-2003 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/rounding.hpp
+++ b/include/boost/numeric/interval/rounding.hpp
@@ -1,6 +1,6 @@
 /* Boost interval/rounding.hpp template implementation file
  *
- * Copyright 2002-2003 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002-2003 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/transc.hpp
+++ b/include/boost/numeric/interval/transc.hpp
@@ -1,7 +1,7 @@
 /* Boost interval/transc.hpp template implementation file
  *
  * Copyright 2000 Jens Maurer
- * Copyright 2002 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/include/boost/numeric/interval/utility.hpp
+++ b/include/boost/numeric/interval/utility.hpp
@@ -1,7 +1,7 @@
 /* Boost interval/utility.hpp template implementation file
  *
  * Copyright 2000 Jens Maurer
- * Copyright 2002-2003 Hervé Brönnimann, Guillaume Melquiond, Sylvain Pion
+ * Copyright 2002-2003 HervÃ© BrÃ¶nnimann, Guillaume Melquiond, Sylvain Pion
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or

--- a/test/bugs.hpp
+++ b/test/bugs.hpp
@@ -2,7 +2,7 @@
  * Handles namespace resolution quirks in older compilers and braindead
  * warnings [Herve, June 3rd 2003]
  *
- * Copyright 2002-2003 Hervé Brönnimann
+ * Copyright 2002-2003 HervÃ© BrÃ¶nnimann
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or


### PR DESCRIPTION
Nearly every header in the boost codebase is UTF-8, but here there
are a few headers which are using Windows-1252, which makes it impossible
for some tools to parse those files. This patch just reencodes them
with UTF-8 like the rest of the codebase. I checked that the name of the
author is still correct after this change and the reencoded string
literal was the plus-minus-sign.

No functional change intended.