### PR TITLE
Missing root index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+<meta http-equiv="refresh" content="0; URL=doc/interval.htm">
+</head>
+<body>
+Automatic redirection failed, please go to
+<a href="doc/interval.htm">doc/interval.htm</a>.&nbsp;<hr>
+<p>© Copyright Beman Dawes, 2001</p>
+<p>Distributed under the Boost Software License, Version 1.0. (See accompanying 
+file <a href="../../../LICENSE_1_0.txt">LICENSE_1_0.txt</a> or copy 
+at <a href="http://www.boost.org/LICENSE_1_0.txt">www.boost.org/LICENSE_1_0.txt</a>)</p>
+</body>
+</html>


### PR DESCRIPTION
Should fix
```
libs/numeric/interval: error: file not found; Did not find [project-root]/index.html file. The file is required for all libraries. Redirection to HTML documentation. <<org-doc-redir>>
```

https://www.boost.org/development/tests/develop/developer/output/teeks99-09-p-win2012R2-64on64-boost-bin-v2-libs-numeric-interval-test-__boost_check_library__-test-msvc-14-1-adrs-mdl-64-pythn-3-7.html