### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/include/boost/numeric/interval/detail/bcc_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/bcc_rounding_control.hpp
@@ -11,7 +11,7 @@
 #ifndef BOOST_NUMERIC_INTERVAL_DETAIL_BCC_ROUNDING_CONTROL_HPP
 #define BOOST_NUMERIC_INTERVAL_DETAIL_BCC_ROUNDING_CONTROL_HPP
 
-#ifndef __BORLANDC__
+#if !defined(__BORLANDC__) || defined(__clang__)
 #  error This header is only intended for Borland C++.
 #endif
 

--- a/include/boost/numeric/interval/detail/x86_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/x86_rounding_control.hpp
@@ -11,7 +11,7 @@
 #ifndef BOOST_NUMERIC_INTERVAL_DETAIL_X86_ROUNDING_CONTROL_HPP
 #define BOOST_NUMERIC_INTERVAL_DETAIL_X86_ROUNDING_CONTROL_HPP
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__BORLANDC__) && defined(__clang__)
 #  include <boost/numeric/interval/detail/x86gcc_rounding_control.hpp>
 #elif defined(__BORLANDC__)
 #  include <boost/numeric/interval/detail/bcc_rounding_control.hpp>

--- a/include/boost/numeric/interval/detail/x86gcc_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/x86gcc_rounding_control.hpp
@@ -11,7 +11,7 @@
 #ifndef BOOST_NUMERIC_INTERVAL_DETAIL_X86GCC_ROUNDING_CONTROL_HPP
 #define BOOST_NUMERIC_INTERVAL_DETAIL_X86GCC_ROUNDING_CONTROL_HPP
 
-#ifndef __GNUC__
+#if !defined(__GNUC__) && !(defined(__BORLANDC__) && defined(__clang__))
 #  error This header only works with GNU CC.
 #endif
 

--- a/include/boost/numeric/interval/hw_rounding.hpp
+++ b/include/boost/numeric/interval/hw_rounding.hpp
@@ -19,7 +19,7 @@
 // define appropriate specialization of rounding_control for built-in types
 #if defined(__x86_64__) && (defined(__USE_ISOC99) || defined(__APPLE__))
 #  include <boost/numeric/interval/detail/c99_rounding_control.hpp>
-#elif defined(__i386__) || defined(_M_IX86) || defined(__BORLANDC__) || defined(_M_X64)
+#elif defined(__i386__) || defined(_M_IX86) || defined(__BORLANDC__) && !defined(__clang__) || defined(_M_X64)
 #  include <boost/numeric/interval/detail/x86_rounding_control.hpp>
 #elif defined(__i386) && defined(__SUNPRO_CC)
 #  include <boost/numeric/interval/detail/x86_rounding_control.hpp>

--- a/test/bugs.hpp
+++ b/test/bugs.hpp
@@ -14,7 +14,7 @@
 // Borland compiler complains about unused variables a bit easily and
 // incorrectly
 
-#ifdef __BORLANDC__
+#ifdef BOOST_BORLANDC
 namespace detail {
 
   template <class T> inline void ignore_unused_variable_warning(const T&) { }
@@ -34,7 +34,7 @@ namespace detail {
 
 // Some compilers are broken with respect to name resolution
 
-#if defined(BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP) || defined( __BORLANDC__)
+#if defined(BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP) || defined( BOOST_BORLANDC)
 
 using namespace boost;
 using namespace numeric;

--- a/test/cmp.cpp
+++ b/test/cmp.cpp
@@ -28,7 +28,7 @@ static void test_12_34() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -52,7 +52,7 @@ static void test_13_24() {
   BOOST_C_EXN(a == b);
   BOOST_C_EXN(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -76,7 +76,7 @@ static void test_12_23() {
   BOOST_C_EXN(a == b);
   BOOST_C_EXN(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -96,7 +96,7 @@ static void test_12_0() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -116,7 +116,7 @@ static void test_12_1() {
   BOOST_C_EXN(a == b);
   BOOST_C_EXN(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -136,7 +136,7 @@ static void test_12_2() {
   BOOST_C_EXN(a == b);
   BOOST_C_EXN(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -156,7 +156,7 @@ static void test_12_3() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -168,7 +168,7 @@ static void test_12_12() {
   const I a(1,2), b(1,2);
   BOOST_C_EXN(a == b);
   BOOST_C_EXN(a != b);
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -180,7 +180,7 @@ static void test_11_11() {
   const I a(1,1), b(1,1);
   BOOST_CHECK(a == b);
   BOOST_CHECK(!(a != b));
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -193,7 +193,7 @@ static void test_11_1() {
   const int b = 1;
   BOOST_CHECK(a == b);
   BOOST_CHECK(!(a != b));
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif

--- a/test/cmp_exp.cpp
+++ b/test/cmp_exp.cpp
@@ -45,7 +45,7 @@ static void test_12_34() {
   BOOST_CHECK(!poseq(b, a));
   BOOST_CHECK(posne(b, a));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -86,7 +86,7 @@ static void test_13_24() {
   BOOST_CHECK(poseq(b, a));
   BOOST_CHECK(posne(b, a));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -127,7 +127,7 @@ static void test_12_23() {
   BOOST_CHECK(poseq(b, a));
   BOOST_CHECK(posne(b, a));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -169,7 +169,7 @@ static void test_12_0() {
   BOOST_CHECK(!poseq(b, a));
   BOOST_CHECK(posne(b, a));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -211,7 +211,7 @@ static void test_12_1() {
   BOOST_CHECK(poseq(b, a));
   BOOST_CHECK(posne(b, a));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -253,7 +253,7 @@ static void test_12_2() {
   BOOST_CHECK(poseq(b, a));
   BOOST_CHECK(posne(b, a));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -295,7 +295,7 @@ static void test_12_3() {
   BOOST_CHECK(!poseq(b, a));
   BOOST_CHECK(posne(b, a));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -311,7 +311,7 @@ static void test_12_12() {
   BOOST_CHECK(!cerne(b, a));
   BOOST_CHECK(poseq(b, a));
   BOOST_CHECK(posne(b, a));
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -327,7 +327,7 @@ static void test_11_11() {
   BOOST_CHECK(!cerne(b, a));
   BOOST_CHECK(poseq(b, a));
   BOOST_CHECK(!posne(b, a));
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -344,7 +344,7 @@ static void test_11_1() {
   BOOST_CHECK(!cerne(b, a));
   BOOST_CHECK(poseq(b, a));
   BOOST_CHECK(!posne(b, a));
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif

--- a/test/cmp_lex.cpp
+++ b/test/cmp_lex.cpp
@@ -30,7 +30,7 @@ static void test_12_34() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -54,7 +54,7 @@ static void test_13_24() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -78,7 +78,7 @@ static void test_12_23() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -98,7 +98,7 @@ static void test_12_0() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -118,7 +118,7 @@ static void test_12_1() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -138,7 +138,7 @@ static void test_12_2() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -158,7 +158,7 @@ static void test_12_3() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -170,7 +170,7 @@ static void test_12_12() {
   BOOST_CHECK(a == b);
   BOOST_CHECK(!(a != b));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -182,7 +182,7 @@ static void test_11_11() {
   BOOST_CHECK(a == b);
   BOOST_CHECK(!(a != b));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -195,7 +195,7 @@ static void test_11_1() {
   BOOST_CHECK(a == b);
   BOOST_CHECK(!(a != b));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif

--- a/test/cmp_set.cpp
+++ b/test/cmp_set.cpp
@@ -30,7 +30,7 @@ static void test_12_34() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -54,7 +54,7 @@ static void test_13_24() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -78,7 +78,7 @@ static void test_14_23() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -102,7 +102,7 @@ static void test_12_23() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -126,7 +126,7 @@ static void test_12_E() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -150,7 +150,7 @@ static void test_E_E() {
   BOOST_CHECK(a == b);
   BOOST_CHECK(!(a != b));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -174,7 +174,7 @@ static void test_12_12() {
   BOOST_CHECK(a == b);
   BOOST_CHECK(!(a != b));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -198,7 +198,7 @@ static void test_11_11() {
   BOOST_CHECK(a == b);
   BOOST_CHECK(!(a != b));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif

--- a/test/cmp_tribool.cpp
+++ b/test/cmp_tribool.cpp
@@ -31,7 +31,7 @@ static void test_12_34() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -55,7 +55,7 @@ static void test_13_24() {
   BOOST_CHECK(indeterminate(a == b));
   BOOST_CHECK(indeterminate(a != b));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -79,7 +79,7 @@ static void test_12_23() {
   BOOST_CHECK(indeterminate(a == b));
   BOOST_CHECK(indeterminate(a != b));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -99,7 +99,7 @@ static void test_12_0() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -119,7 +119,7 @@ static void test_12_1() {
   BOOST_CHECK(indeterminate(a == b));
   BOOST_CHECK(indeterminate(a != b));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -139,7 +139,7 @@ static void test_12_2() {
   BOOST_CHECK(indeterminate(a == b));
   BOOST_CHECK(indeterminate(a != b));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -159,7 +159,7 @@ static void test_12_3() {
   BOOST_CHECK(!(a == b));
   BOOST_CHECK(a != b);
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -173,7 +173,7 @@ static void test_12_12() {
   BOOST_CHECK(indeterminate(a == b));
   BOOST_CHECK(indeterminate(a != b));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -187,7 +187,7 @@ static void test_11_11() {
   BOOST_CHECK(a == b);
   BOOST_CHECK(!(a != b));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif
@@ -202,7 +202,7 @@ static void test_11_1() {
   BOOST_CHECK(a == b);
   BOOST_CHECK(!(a != b));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(a);
   ::detail::ignore_unused_variable_warning(b);
 # endif

--- a/test/det.cpp
+++ b/test/det.cpp
@@ -96,7 +96,7 @@ int test_main(int, char *[]) {
   BOOST_CHECK(test<float>());
   BOOST_CHECK(test<double>());
   BOOST_CHECK(test<long double>());
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_warnings();
 # endif
   return 0;

--- a/test/integer.cpp
+++ b/test/integer.cpp
@@ -17,7 +17,7 @@ typedef boost::numeric::interval<float> I;
 int main() {
   I x, y;
   x = 4 - (2 * y + 1) / 3;
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_warnings();
 # endif
   return 0;

--- a/test/msvc_x64_flags.cpp
+++ b/test/msvc_x64_flags.cpp
@@ -14,7 +14,7 @@
 int test_main(int, char *[]) {
   boost::numeric::interval<double> i(0.0, 0.0);
   boost::numeric::interval<double> i2 = 60.0 - i;
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_warnings();
 # endif
   return 0;

--- a/test/mul.cpp
+++ b/test/mul.cpp
@@ -117,7 +117,7 @@ int test_main(int, char*[]) {
   BOOST_CHECK(test_sqrt(5, 7));
   BOOST_CHECK(test_sqrt(-1, 2));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_warnings();
 # endif
   return 0;

--- a/test/overflow.cpp
+++ b/test/overflow.cpp
@@ -20,7 +20,7 @@ void test_one(typename I::base_type x, typename I::base_type f) {
   for(int i = 0; i < nb; i++) y *= f;
   for(int i = 0; i < nb; i++) y *= g;
   BOOST_CHECK(in(x, y));
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_unused_variable_warning(nb);
 # endif
 }
@@ -37,7 +37,7 @@ int test_main(int, char *[]) {
   test<boost::numeric::interval<float> >();
   test<boost::numeric::interval<double> >();
   //test<boost::numeric::interval<long double> >();
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_warnings();
 # endif
   return 0;

--- a/test/pow.cpp
+++ b/test/pow.cpp
@@ -35,7 +35,7 @@ int test_main(int, char *[]) {
   BOOST_CHECK(test_pow(-3, 2, 1, 1, 0));
   BOOST_CHECK(test_pow(-3, -2, 1, 1, 0));
 
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_warnings();
 # endif
   return 0;

--- a/test/test_float.cpp
+++ b/test/test_float.cpp
@@ -121,7 +121,7 @@ int test_main(int, char *[]) {
   //BOOST_TEST_CHECKPOINT("long double tests");
   //test_all_unaries<long double>();
   //test_all_binaries<long double>();
-# ifdef __BORLANDC__
+# ifdef BOOST_BORLANDC
   ::detail::ignore_warnings();
 # endif
   return 0;


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.