### PR TITLE
Use BOOST_NO_FENV_H to detect whether <fenv.h> is supported (fix #24).

### DIFF
--- a/include/boost/numeric/interval/hw_rounding.hpp
+++ b/include/boost/numeric/interval/hw_rounding.hpp
@@ -11,13 +11,14 @@
 #ifndef BOOST_NUMERIC_INTERVAL_HW_ROUNDING_HPP
 #define BOOST_NUMERIC_INTERVAL_HW_ROUNDING_HPP
 
+#include <boost/config.hpp>
 #include <boost/numeric/interval/rounding.hpp>
 #include <boost/numeric/interval/rounded_arith.hpp>
 
 #define BOOST_NUMERIC_INTERVAL_NO_HARDWARE
 
 // define appropriate specialization of rounding_control for built-in types
-#if defined(__x86_64__) && (defined(__USE_ISOC99) || defined(__APPLE__))
+#if defined(__x86_64__) && !defined(BOOST_NO_FENV_H)
 #  include <boost/numeric/interval/detail/c99_rounding_control.hpp>
 #elif defined(__i386__) || defined(_M_IX86) || defined(__BORLANDC__) && !defined(__clang__) || defined(_M_X64)
 #  include <boost/numeric/interval/detail/x86_rounding_control.hpp>
@@ -33,7 +34,7 @@
 #  include <boost/numeric/interval/detail/ia64_rounding_control.hpp>
 #endif
 
-#if defined(BOOST_NUMERIC_INTERVAL_NO_HARDWARE) && (defined(__USE_ISOC99) || defined(__MSL__))
+#if defined(BOOST_NUMERIC_INTERVAL_NO_HARDWARE) && !defined(BOOST_NO_FENV_H)
 #  include <boost/numeric/interval/detail/c99_rounding_control.hpp>
 #endif
 


### PR DESCRIPTION
This should fix compilation on platforms that provide <fenv.h> but do not set __USE_ISOC99.