### PR TITLE
Fix test Jamfile.v2 to be location independent.

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -8,7 +8,6 @@
 
 project
   :
-  source-location $(BOOST_ROOT)
   :
   requirements
     # Enable dynamic rounding on Tru64 (Alpha CPU).
@@ -24,25 +23,25 @@ import testing ;
 
 {
   test-suite numeric/interval :
-    [ compile libs/numeric/interval/test/integer.cpp ]
+    [ compile integer.cpp ]
 
-    [ run libs/numeric/interval/test/add.cpp      ]
-    [ run libs/numeric/interval/test/det.cpp      ]
-    [ run libs/numeric/interval/test/fmod.cpp     ]
-    [ run libs/numeric/interval/test/msvc_x64_flags.cpp : : : <build>no <toolset>msvc:<build>yes ]
-    [ run libs/numeric/interval/test/mul.cpp      ]
-    [ run libs/numeric/interval/test/overflow.cpp ]
-    [ run libs/numeric/interval/test/pi.cpp       ]
-    [ run libs/numeric/interval/test/pow.cpp      ]
+    [ run add.cpp      ]
+    [ run det.cpp      ]
+    [ run fmod.cpp     ]
+    [ run msvc_x64_flags.cpp : : : <build>no <toolset>msvc:<build>yes ]
+    [ run mul.cpp      ]
+    [ run overflow.cpp ]
+    [ run pi.cpp       ]
+    [ run pow.cpp      ]
 
-    [ run libs/numeric/interval/test/cmp.cpp ]
-    [ run libs/numeric/interval/test/cmp_exn.cpp ]
-    [ run libs/numeric/interval/test/cmp_exp.cpp ]
-    [ run libs/numeric/interval/test/cmp_lex.cpp ]
-    [ run libs/numeric/interval/test/cmp_set.cpp ]
+    [ run cmp.cpp ]
+    [ run cmp_exn.cpp ]
+    [ run cmp_exp.cpp ]
+    [ run cmp_lex.cpp ]
+    [ run cmp_set.cpp ]
  # https://github.com/boostorg/interval/issues/15
- #  [ run libs/numeric/interval/test/cmp_tribool.cpp ]
-    [ run libs/numeric/interval/test/test_float.cpp
+ #  [ run cmp_tribool.cpp ]
+    [ run test_float.cpp
       : : : <build>yes <toolset>msvc-10.0:<build>no ]
             # https://github.com/boostorg/interval/issues/17
   ;


### PR DESCRIPTION
In order to make the library transportable, specifically so we can support modular Boost distribution, we need to avoid encoding absolute paths in the monolithic Boost structure. This changes the test source reference to all be local to the project.