### PR TITLE
WIP: Add CUDA support

### DIFF
--- a/include/boost/numeric/interval/arith.hpp
+++ b/include/boost/numeric/interval/arith.hpp
@@ -136,6 +136,14 @@ template<class T, class Policies> inline
 BOOST_GPU_ENABLED interval<T, Policies> operator+(const interval<T, Policies>& x, const T& y)
 { return y + x; }
 
+template<class T1, class Policies, class T2> inline
+BOOST_GPU_ENABLED interval<T1, Policies> operator+(const T2& x, const interval<T1, Policies>& y)
+{ return static_cast<T1>(x) + y; }
+
+template<class T1, class Policies, class T2> inline
+BOOST_GPU_ENABLED interval<T1, Policies> operator+(const interval<T1, Policies>& x, const T2& y)
+{ return x + static_cast<T1>(y); }
+
 template<class T, class Policies> inline
 BOOST_GPU_ENABLED interval<T, Policies> operator-(const interval<T, Policies>& x,
                                 const interval<T, Policies>& y)
@@ -147,8 +155,8 @@ BOOST_GPU_ENABLED interval<T, Policies> operator-(const interval<T, Policies>& x
                               rnd.sub_up  (x.upper(), y.lower()), true);
 }
 
-template<class T, class Policies> inline
-BOOST_GPU_ENABLED interval<T, Policies> operator-(const T& x, const interval<T, Policies>& y)
+  template<class T, class Policies> inline
+  BOOST_GPU_ENABLED interval<T, Policies> operator-(const T& x, const interval<T, Policies>& y)
 {
   if (interval_lib::detail::test_input(x, y))
     return interval<T, Policies>::empty();
@@ -166,6 +174,14 @@ BOOST_GPU_ENABLED interval<T, Policies> operator-(const interval<T, Policies>& x
   return interval<T,Policies>(rnd.sub_down(x.lower(), y),
                               rnd.sub_up  (x.upper(), y), true);
 }
+
+template<class T1, class Policies, class T2> inline
+BOOST_GPU_ENABLED interval<T1, Policies> operator-(const T2& x, const interval<T1, Policies>& y)
+{ return static_cast<T1>(x) - y; }
+
+template<class T1, class Policies, class T2> inline
+BOOST_GPU_ENABLED interval<T1, Policies> operator-(const interval<T1, Policies>& x, const T2& y)
+{ return x - static_cast<T1>(y); }
 
 template<class T, class Policies> inline
 BOOST_GPU_ENABLED interval<T, Policies> operator*(const interval<T, Policies>& x,
@@ -244,6 +260,14 @@ template<class T, class Policies> inline
 BOOST_GPU_ENABLED interval<T, Policies> operator*(const interval<T, Policies>& x, const T& y)
 { return y * x; }
 
+template<class T1, class Policies, class T2> inline
+BOOST_GPU_ENABLED interval<T1, Policies> operator*(const T2& x, const interval<T1, Policies>& y)
+{ return static_cast<T1>(x) * y; }
+
+template<class T1, class Policies, class T2> inline
+BOOST_GPU_ENABLED interval<T1, Policies> operator*(const interval<T1, Policies>& x, const T2& y)
+{ return x * static_cast<T1>(y); }
+
 template<class T, class Policies> inline
 BOOST_GPU_ENABLED interval<T, Policies> operator/(const interval<T, Policies>& x,
                                 const interval<T, Policies>& y)
@@ -298,6 +322,10 @@ BOOST_GPU_ENABLED interval<T, Policies> operator/(const interval<T, Policies>& x
   else
     return interval<T, Policies>(rnd.div_down(xl, y), rnd.div_up(xu, y), true);
 }
+
+template<class T1, class Policies, class T2> inline
+BOOST_GPU_ENABLED interval<T1, Policies> operator/(const T2& x, const interval<T1, Policies>& y)
+{ return static_cast<T1>(x) / y; }
 
 } // namespace numeric
 } // namespace boost

--- a/include/boost/numeric/interval/arith.hpp
+++ b/include/boost/numeric/interval/arith.hpp
@@ -26,13 +26,13 @@ namespace numeric {
  */
 
 template<class T, class Policies> inline
-const interval<T, Policies>& operator+(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED const interval<T, Policies>& operator+(const interval<T, Policies>& x)
 {
   return x;
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator-(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> operator-(const interval<T, Policies>& x)
 {
   if (interval_lib::detail::test_input(x))
     return interval<T, Policies>::empty();
@@ -40,7 +40,7 @@ interval<T, Policies> operator-(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies>& interval<T, Policies>::operator+=(const interval<T, Policies>& r)
+BOOST_GPU_ENABLED interval<T, Policies>& interval<T, Policies>::operator+=(const interval<T, Policies>& r)
 {
   if (interval_lib::detail::test_input(*this, r))
     set_empty();
@@ -52,7 +52,7 @@ interval<T, Policies>& interval<T, Policies>::operator+=(const interval<T, Polic
 }
 
 template<class T, class Policies> inline
-interval<T, Policies>& interval<T, Policies>::operator+=(const T& r)
+BOOST_GPU_ENABLED interval<T, Policies>& interval<T, Policies>::operator+=(const T& r)
 {
   if (interval_lib::detail::test_input(*this, r))
     set_empty();
@@ -64,7 +64,7 @@ interval<T, Policies>& interval<T, Policies>::operator+=(const T& r)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies>& interval<T, Policies>::operator-=(const interval<T, Policies>& r)
+BOOST_GPU_ENABLED interval<T, Policies>& interval<T, Policies>::operator-=(const interval<T, Policies>& r)
 {
   if (interval_lib::detail::test_input(*this, r))
     set_empty();
@@ -76,7 +76,7 @@ interval<T, Policies>& interval<T, Policies>::operator-=(const interval<T, Polic
 }
 
 template<class T, class Policies> inline
-interval<T, Policies>& interval<T, Policies>::operator-=(const T& r)
+BOOST_GPU_ENABLED interval<T, Policies>& interval<T, Policies>::operator-=(const T& r)
 {
   if (interval_lib::detail::test_input(*this, r))
     set_empty();
@@ -88,32 +88,32 @@ interval<T, Policies>& interval<T, Policies>::operator-=(const T& r)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies>& interval<T, Policies>::operator*=(const interval<T, Policies>& r)
+BOOST_GPU_ENABLED interval<T, Policies>& interval<T, Policies>::operator*=(const interval<T, Policies>& r)
 {
   return *this = *this * r;
 }
 
 template<class T, class Policies> inline
-interval<T, Policies>& interval<T, Policies>::operator*=(const T& r)
+BOOST_GPU_ENABLED interval<T, Policies>& interval<T, Policies>::operator*=(const T& r)
 {
   return *this = r * *this;
 }
 
 template<class T, class Policies> inline
-interval<T, Policies>& interval<T, Policies>::operator/=(const interval<T, Policies>& r)
+BOOST_GPU_ENABLED interval<T, Policies>& interval<T, Policies>::operator/=(const interval<T, Policies>& r)
 {
   return *this = *this / r;
 }
 
 template<class T, class Policies> inline
-interval<T, Policies>& interval<T, Policies>::operator/=(const T& r)
+BOOST_GPU_ENABLED interval<T, Policies>& interval<T, Policies>::operator/=(const T& r)
 {
   return *this = *this / r;
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator+(const interval<T, Policies>& x,
-                                const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> operator+(const interval<T, Policies>& x,
+                                                  const interval<T, Policies>& y)
 {
   if (interval_lib::detail::test_input(x, y))
     return interval<T, Policies>::empty();
@@ -123,7 +123,7 @@ interval<T, Policies> operator+(const interval<T, Policies>& x,
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator+(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> operator+(const T& x, const interval<T, Policies>& y)
 {
   if (interval_lib::detail::test_input(x, y))
     return interval<T, Policies>::empty();
@@ -133,11 +133,11 @@ interval<T, Policies> operator+(const T& x, const interval<T, Policies>& y)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator+(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED interval<T, Policies> operator+(const interval<T, Policies>& x, const T& y)
 { return y + x; }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator-(const interval<T, Policies>& x,
+BOOST_GPU_ENABLED interval<T, Policies> operator-(const interval<T, Policies>& x,
                                 const interval<T, Policies>& y)
 {
   if (interval_lib::detail::test_input(x, y))
@@ -148,7 +148,7 @@ interval<T, Policies> operator-(const interval<T, Policies>& x,
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator-(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> operator-(const T& x, const interval<T, Policies>& y)
 {
   if (interval_lib::detail::test_input(x, y))
     return interval<T, Policies>::empty();
@@ -158,7 +158,7 @@ interval<T, Policies> operator-(const T& x, const interval<T, Policies>& y)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator-(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED interval<T, Policies> operator-(const interval<T, Policies>& x, const T& y)
 {
   if (interval_lib::detail::test_input(x, y))
     return interval<T, Policies>::empty();
@@ -168,8 +168,8 @@ interval<T, Policies> operator-(const interval<T, Policies>& x, const T& y)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator*(const interval<T, Policies>& x,
-                                const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> operator*(const interval<T, Policies>& x,
+                                                  const interval<T, Policies>& y)
 {
   BOOST_USING_STD_MIN();
   BOOST_USING_STD_MAX();
@@ -223,7 +223,7 @@ interval<T, Policies> operator*(const interval<T, Policies>& x,
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator*(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> operator*(const T& x, const interval<T, Policies>& y)
 { 
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x, y))
@@ -241,11 +241,11 @@ interval<T, Policies> operator*(const T& x, const interval<T, Policies>& y)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator*(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED interval<T, Policies> operator*(const interval<T, Policies>& x, const T& y)
 { return y * x; }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator/(const interval<T, Policies>& x,
+BOOST_GPU_ENABLED interval<T, Policies> operator/(const interval<T, Policies>& x,
                                 const interval<T, Policies>& y)
 {
   if (interval_lib::detail::test_input(x, y))
@@ -266,7 +266,7 @@ interval<T, Policies> operator/(const interval<T, Policies>& x,
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator/(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> operator/(const T& x, const interval<T, Policies>& y)
 {
   if (interval_lib::detail::test_input(x, y))
     return interval<T, Policies>::empty();
@@ -286,7 +286,7 @@ interval<T, Policies> operator/(const T& x, const interval<T, Policies>& y)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator/(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED interval<T, Policies> operator/(const interval<T, Policies>& x, const T& y)
 {
   if (interval_lib::detail::test_input(x, y) || interval_lib::user::is_zero(y))
     return interval<T, Policies>::empty();

--- a/include/boost/numeric/interval/arith2.hpp
+++ b/include/boost/numeric/interval/arith2.hpp
@@ -29,8 +29,8 @@ namespace boost {
 namespace numeric {
 
 template<class T, class Policies> inline
-interval<T, Policies> fmod(const interval<T, Policies>& x,
-                           const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> fmod(const interval<T, Policies>& x,
+                                             const interval<T, Policies>& y)
 {
   if (interval_lib::detail::test_input(x, y))
     return interval<T, Policies>::empty();
@@ -42,7 +42,7 @@ interval<T, Policies> fmod(const interval<T, Policies>& x,
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> fmod(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED interval<T, Policies> fmod(const interval<T, Policies>& x, const T& y)
 {
   if (interval_lib::detail::test_input(x, y))
     return interval<T, Policies>::empty();
@@ -53,7 +53,7 @@ interval<T, Policies> fmod(const interval<T, Policies>& x, const T& y)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> fmod(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> fmod(const T& x, const interval<T, Policies>& y)
 {
   if (interval_lib::detail::test_input(x, y))
     return interval<T, Policies>::empty();
@@ -67,8 +67,8 @@ interval<T, Policies> fmod(const T& x, const interval<T, Policies>& y)
 namespace interval_lib {
 
 template<class T, class Policies> inline
-interval<T, Policies> division_part1(const interval<T, Policies>& x,
-                                     const interval<T, Policies>& y, bool& b)
+BOOST_GPU_ENABLED interval<T, Policies> division_part1(const interval<T, Policies>& x,
+                                                       const interval<T, Policies>& y, bool& b)
 {
   typedef interval<T, Policies> I;
   b = false;
@@ -90,15 +90,15 @@ interval<T, Policies> division_part1(const interval<T, Policies>& x,
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> division_part2(const interval<T, Policies>& x,
-                                     const interval<T, Policies>& y, bool b = true)
+BOOST_GPU_ENABLED interval<T, Policies> division_part2(const interval<T, Policies>& x,
+                                                       const interval<T, Policies>& y, bool b = true)
 {
   if (!b) return interval<T, Policies>::empty();
   return detail::div_zero_part2(x, y);
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> multiplicative_inverse(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> multiplicative_inverse(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (detail::test_input(x))
@@ -124,7 +124,7 @@ interval<T, Policies> multiplicative_inverse(const interval<T, Policies>& x)
 namespace detail {
 
 template<class T, class Rounding> inline
-T pow_dn(const T& x_, int pwr, Rounding& rnd) // x and pwr are positive
+BOOST_GPU_ENABLED T pow_dn(const T& x_, int pwr, Rounding& rnd) // x and pwr are positive
 {
   T x = x_;
   T y = (pwr & 1) ? x_ : static_cast<T>(1);
@@ -138,7 +138,7 @@ T pow_dn(const T& x_, int pwr, Rounding& rnd) // x and pwr are positive
 }
 
 template<class T, class Rounding> inline
-T pow_up(const T& x_, int pwr, Rounding& rnd) // x and pwr are positive
+BOOST_GPU_ENABLED T pow_up(const T& x_, int pwr, Rounding& rnd) // x and pwr are positive
 {
   T x = x_;
   T y = (pwr & 1) ? x_ : static_cast<T>(1);
@@ -155,7 +155,7 @@ T pow_up(const T& x_, int pwr, Rounding& rnd) // x and pwr are positive
 } // namespace interval_lib
 
 template<class T, class Policies> inline
-interval<T, Policies> pow(const interval<T, Policies>& x, int pwr)
+BOOST_GPU_ENABLED interval<T, Policies> pow(const interval<T, Policies>& x, int pwr)
 {
   BOOST_USING_STD_MAX();
   using interval_lib::detail::pow_dn;
@@ -195,7 +195,7 @@ interval<T, Policies> pow(const interval<T, Policies>& x, int pwr)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> sqrt(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> sqrt(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x) || interval_lib::user::is_neg(x.upper()))
@@ -206,7 +206,7 @@ interval<T, Policies> sqrt(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> square(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> square(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x))
@@ -226,7 +226,7 @@ namespace interval_lib {
 namespace detail {
 
 template< class I > inline
-I root_aux(typename I::base_type const &x, int k) // x and k are bigger than one
+BOOST_GPU_ENABLED I root_aux(typename I::base_type const &x, int k) // x and k are bigger than one
 {
   typedef typename I::base_type T;
   T tk(k);
@@ -240,7 +240,7 @@ I root_aux(typename I::base_type const &x, int k) // x and k are bigger than one
 }
 
 template< class I > inline // x is positive and k bigger than one
-typename I::base_type root_aux_dn(typename I::base_type const &x, int k)
+BOOST_GPU_ENABLED typename I::base_type root_aux_dn(typename I::base_type const &x, int k)
 {
   typedef typename I::base_type T;
   typedef typename I::traits_type Policies;
@@ -252,7 +252,7 @@ typename I::base_type root_aux_dn(typename I::base_type const &x, int k)
 }
 
 template< class I > inline // x is positive and k bigger than one
-typename I::base_type root_aux_up(typename I::base_type const &x, int k)
+BOOST_GPU_ENABLED typename I::base_type root_aux_up(typename I::base_type const &x, int k)
 {
   typedef typename I::base_type T;
   typedef typename I::traits_type Policies;
@@ -267,7 +267,7 @@ typename I::base_type root_aux_up(typename I::base_type const &x, int k)
 } // namespace interval_lib
 
 template< class T, class Policies > inline
-interval<T, Policies> nth_root(interval<T, Policies> const &x, int k)
+BOOST_GPU_ENABLED interval<T, Policies> nth_root(interval<T, Policies> const &x, int k)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x)) return I::empty();

--- a/include/boost/numeric/interval/arith3.hpp
+++ b/include/boost/numeric/interval/arith3.hpp
@@ -23,7 +23,7 @@ namespace numeric {
 namespace interval_lib {
 
 template<class I> inline
-I add(const typename I::base_type& x, const typename I::base_type& y)
+BOOST_GPU_ENABLED I add(const typename I::base_type& x, const typename I::base_type& y)
 {
   typedef typename I::traits_type Policies;
   if (detail::test_input<typename I::base_type, Policies>(x, y))
@@ -33,7 +33,7 @@ I add(const typename I::base_type& x, const typename I::base_type& y)
 }
 
 template<class I> inline
-I sub(const typename I::base_type& x, const typename I::base_type& y)
+BOOST_GPU_ENABLED I sub(const typename I::base_type& x, const typename I::base_type& y)
 {
   typedef typename I::traits_type Policies;
   if (detail::test_input<typename I::base_type, Policies>(x, y))
@@ -43,7 +43,7 @@ I sub(const typename I::base_type& x, const typename I::base_type& y)
 }
 
 template<class I> inline
-I mul(const typename I::base_type& x, const typename I::base_type& y)
+BOOST_GPU_ENABLED I mul(const typename I::base_type& x, const typename I::base_type& y)
 {
   typedef typename I::traits_type Policies;
   if (detail::test_input<typename I::base_type, Policies>(x, y))
@@ -53,7 +53,7 @@ I mul(const typename I::base_type& x, const typename I::base_type& y)
 }
 
 template<class I> inline
-I div(const typename I::base_type& x, const typename I::base_type& y)
+BOOST_GPU_ENABLED I div(const typename I::base_type& x, const typename I::base_type& y)
 {
   typedef typename I::traits_type Policies;
   if (detail::test_input<typename I::base_type, Policies>(x, y) || user::is_zero(y))

--- a/include/boost/numeric/interval/checking.hpp
+++ b/include/boost/numeric/interval/checking.hpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <cassert>
 #include <boost/limits.hpp>
+#include <boost/numeric/interval/detail/bugs.hpp>
 
 namespace boost {
 namespace numeric {
@@ -21,53 +22,59 @@ namespace interval_lib {
 
 struct exception_create_empty
 {
-  void operator()()
+  BOOST_GPU_ENABLED void operator()()
   {
-    throw std::runtime_error("boost::interval: empty interval created");
+    BOOST_NUMERIC_INTERVAL_throw("boost::interval: empty interval created");
   }
 };
 
 struct exception_invalid_number
 {
-  void operator()()
+  BOOST_GPU_ENABLED void operator()()
   {
-    throw std::invalid_argument("boost::interval: invalid number");
+    BOOST_NUMERIC_INTERVAL_throw("boost::interval: invalid number");
   }
 };
 
 template<class T>
 struct checking_base
 {
-  static T pos_inf()
+  BOOST_GPU_ENABLED static T pos_inf()
   {
-    assert(std::numeric_limits<T>::has_infinity);
-    return std::numeric_limits<T>::infinity();
+    BOOST_NUMERIC_INTERVAL_using_std(numeric_limits);
+    assert(numeric_limits<T>::has_infinity);
+    return numeric_limits<T>::infinity();
   }
-  static T neg_inf()
+  BOOST_GPU_ENABLED static T neg_inf()
   {
-    assert(std::numeric_limits<T>::has_infinity);
-    return -std::numeric_limits<T>::infinity();
+    BOOST_NUMERIC_INTERVAL_using_std(numeric_limits);
+    assert(numeric_limits<T>::has_infinity);
+    return -numeric_limits<T>::infinity();
   }
-  static T nan()
+  BOOST_GPU_ENABLED static T nan()
   {
-    assert(std::numeric_limits<T>::has_quiet_NaN);
-    return std::numeric_limits<T>::quiet_NaN();
+    BOOST_NUMERIC_INTERVAL_using_std(numeric_limits);
+    assert(numeric_limits<T>::has_quiet_NaN);
+    return numeric_limits<T>::quiet_NaN();
   }
-  static bool is_nan(const T& x)
+  BOOST_GPU_ENABLED static bool is_nan(const T& x)
   {
-    return std::numeric_limits<T>::has_quiet_NaN && (x != x);
+    BOOST_NUMERIC_INTERVAL_using_std(numeric_limits);
+    return numeric_limits<T>::has_quiet_NaN && (x != x);
   }
-  static T empty_lower()
+  BOOST_GPU_ENABLED static T empty_lower()
   {
-    return (std::numeric_limits<T>::has_quiet_NaN ?
-            std::numeric_limits<T>::quiet_NaN() : static_cast<T>(1));
+    BOOST_NUMERIC_INTERVAL_using_std(numeric_limits);
+    return (numeric_limits<T>::has_quiet_NaN) ?
+            numeric_limits<T>::quiet_NaN() : static_cast<T>(1);
   }
-  static T empty_upper()
+  BOOST_GPU_ENABLED static T empty_upper()
   {
-    return (std::numeric_limits<T>::has_quiet_NaN ?
-            std::numeric_limits<T>::quiet_NaN() : static_cast<T>(0));
+    BOOST_NUMERIC_INTERVAL_using_std(numeric_limits);
+    return (numeric_limits<T>::has_quiet_NaN) ?
+            numeric_limits<T>::quiet_NaN() : static_cast<T>(0);
   }
-  static bool is_empty(const T& l, const T& u)
+  BOOST_GPU_ENABLED static bool is_empty(const T& l, const T& u)
   {
     return !(l <= u); // safety for partial orders
   }
@@ -77,22 +84,22 @@ template<class T, class Checking = checking_base<T>,
          class Exception = exception_create_empty>
 struct checking_no_empty: Checking
 {
-  static T nan()
+  BOOST_GPU_ENABLED static T nan()
   {
-    assert(false);
+    assert(false); // ?
     return Checking::nan();
   }
-  static T empty_lower()
+  BOOST_GPU_ENABLED static T empty_lower()
   {
     Exception()();
     return Checking::empty_lower();
   }
-  static T empty_upper()
+  BOOST_GPU_ENABLED static T empty_upper()
   {
     Exception()();
     return Checking::empty_upper();
   }
-  static bool is_empty(const T&, const T&)
+  BOOST_GPU_ENABLED static bool is_empty(const T&, const T&)
   {
     return false;
   }
@@ -101,7 +108,7 @@ struct checking_no_empty: Checking
 template<class T, class Checking = checking_base<T> >
 struct checking_no_nan: Checking
 {
-  static bool is_nan(const T&)
+  BOOST_GPU_ENABLED static bool is_nan(const T&)
   {
     return false;
   }
@@ -111,9 +118,11 @@ template<class T, class Checking = checking_base<T>,
          class Exception = exception_invalid_number>
 struct checking_catch_nan: Checking
 {
-  static bool is_nan(const T& x)
+  BOOST_GPU_ENABLED static bool is_nan(const T& x)
   {
-    if (Checking::is_nan(x)) Exception()();
+    if (Checking::is_nan(x)) {
+      Exception()();
+    }
     return false;
   }
 };

--- a/include/boost/numeric/interval/compare/certain.hpp
+++ b/include/boost/numeric/interval/compare/certain.hpp
@@ -20,86 +20,110 @@ namespace compare {
 namespace certain {
 
 template<class T, class Policies1, class Policies2> inline
-bool operator<(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator<(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) {
+    comparison_error()();
+  }
   return x.upper() < y.lower();
 }
 
 template<class T, class Policies> inline
-bool operator<(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator<(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) {
+    comparison_error()();
+  }
   return x.upper() < y;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator<=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator<=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) {
+    comparison_error()();
+  }
   return x.upper() <= y.lower();
 }
 
 template<class T, class Policies> inline
-bool operator<=(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator<=(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) {
+    comparison_error()();
+  }
   return x.upper() <= y;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator>(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator>(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) {
+    comparison_error()();
+  }
   return x.lower() > y.upper();
 }
 
 template<class T, class Policies> inline
-bool operator>(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator>(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) {
+    comparison_error()();
+  }
   return x.lower() > y;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator>=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator>=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) {
+    comparison_error()();
+  }
   return x.lower() >= y.upper();
 }
 
 template<class T, class Policies> inline
-bool operator>=(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator>=(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) {
+    comparison_error()();
+  }
   return x.lower() >= y;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator==(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator==(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) {
+    comparison_error()();
+  }
   return x.upper() == y.lower() && x.lower() == y.upper();
 }
 
 template<class T, class Policies> inline
-bool operator==(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator==(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) {
+    comparison_error()();
+  }
   return x.upper() == y && x.lower() == y;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator!=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator!=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) {
+    comparison_error()();
+  }
   return x.upper() < y.lower() || x.lower() > y.upper();
 }
 
 template<class T, class Policies> inline
-bool operator!=(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator!=(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) {
+    comparison_error()();
+  }
   return x.upper() < y || x.lower() > y;
 }
 

--- a/include/boost/numeric/interval/compare/explicit.hpp
+++ b/include/boost/numeric/interval/compare/explicit.hpp
@@ -22,109 +22,109 @@ namespace interval_lib {
  */
 
 template<class T, class Policies1, class Policies2> inline
-bool cerlt(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool cerlt(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return x.upper() < y.lower();
 }
 
 template<class T, class Policies> inline
-bool cerlt(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool cerlt(const interval<T, Policies>& x, const T& y)
 {
   return x.upper() < y;
 }
 
 template<class T, class Policies> inline
-bool cerlt(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED bool cerlt(const T& x, const interval<T, Policies>& y)
 {
   return x < y.lower();
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool cerle(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool cerle(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return x.upper() <= y.lower();
 }
 
 template<class T, class Policies> inline
-bool cerle(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool cerle(const interval<T, Policies>& x, const T& y)
 {
   return x.upper() <= y;
 }
 
 template<class T, class Policies> inline
-bool cerle(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED bool cerle(const T& x, const interval<T, Policies>& y)
 {
   return x <= y.lower();
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool cergt(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool cergt(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return x.lower() > y.upper();
 }
 
 template<class T, class Policies> inline
-bool cergt(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool cergt(const interval<T, Policies>& x, const T& y)
 {
   return x.lower() > y;
 }
 
 template<class T, class Policies> inline
-bool cergt(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED bool cergt(const T& x, const interval<T, Policies>& y)
 {
   return x > y.upper();
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool cerge(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool cerge(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return x.lower() >= y.upper();
 }
 
 template<class T, class Policies> inline
-bool cerge(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool cerge(const interval<T, Policies>& x, const T& y)
 {
   return x.lower() >= y;
 }
 
 template<class T, class Policies> inline
-bool cerge(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED bool cerge(const T& x, const interval<T, Policies>& y)
 {
   return x >= y.upper();
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool cereq(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool cereq(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return x.lower() == y.upper() && y.lower() == x.upper();
 }
 
 template<class T, class Policies> inline
-bool cereq(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool cereq(const interval<T, Policies>& x, const T& y)
 {
   return x.lower() == y && x.upper() == y;
 }
 
 template<class T, class Policies> inline
-bool cereq(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED bool cereq(const T& x, const interval<T, Policies>& y)
 {
   return x == y.lower() && x == y.upper();
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool cerne(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool cerne(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return x.upper() < y.lower() || y.upper() < x.lower();
 }
 
 template<class T, class Policies> inline
-bool cerne(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool cerne(const interval<T, Policies>& x, const T& y)
 {
   return x.upper() < y || y < x.lower();
 }
 
 template<class T, class Policies> inline
-bool cerne(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED bool cerne(const T& x, const interval<T, Policies>& y)
 {
   return x < y.lower() || y.upper() < x;
 }
@@ -134,109 +134,109 @@ bool cerne(const T& x, const interval<T, Policies>& y)
  */
 
 template<class T, class Policies1, class Policies2> inline
-bool poslt(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool poslt(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return x.lower() < y.upper();
 }
 
 template<class T, class Policies> inline
-bool poslt(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool poslt(const interval<T, Policies>& x, const T& y)
 {
   return x.lower() < y;
 }
 
 template<class T, class Policies> inline
-bool poslt(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED bool poslt(const T& x, const interval<T, Policies>& y)
 {
   return x < y.upper();
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool posle(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool posle(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return x.lower() <= y.upper();
 }
 
 template<class T, class Policies> inline
-bool posle(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool posle(const interval<T, Policies>& x, const T& y)
 {
   return x.lower() <= y;
 }
 
 template<class T, class Policies> inline
-bool posle(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED bool posle(const T& x, const interval<T, Policies>& y)
 {
   return x <= y.upper();
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool posgt(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool posgt(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return x.upper() > y.lower();
 }
 
 template<class T, class Policies> inline
-bool posgt(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool posgt(const interval<T, Policies>& x, const T& y)
 {
   return x.upper() > y;
 }
 
 template<class T, class Policies> inline
-bool posgt(const T& x, const interval<T, Policies> & y)
+BOOST_GPU_ENABLED bool posgt(const T& x, const interval<T, Policies> & y)
 {
   return x > y.lower();
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool posge(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool posge(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return x.upper() >= y.lower();
 }
 
 template<class T, class Policies> inline
-bool posge(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool posge(const interval<T, Policies>& x, const T& y)
 {
   return x.upper() >= y;
 }
 
 template<class T, class Policies> inline
-bool posge(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED bool posge(const T& x, const interval<T, Policies>& y)
 {
   return x >= y.lower();
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool poseq(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool poseq(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return x.upper() >= y.lower() && y.upper() >= x.lower();
 }
 
 template<class T, class Policies> inline
-bool poseq(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool poseq(const interval<T, Policies>& x, const T& y)
 {
   return x.upper() >= y && y >= x.lower();
 }
 
 template<class T, class Policies> inline
-bool poseq(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED bool poseq(const T& x, const interval<T, Policies>& y)
 {
   return x >= y.lower() && y.upper() >= x;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool posne(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool posne(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return x.upper() != y.lower() || y.upper() != x.lower();
 }
 
 template<class T, class Policies> inline
-bool posne(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool posne(const interval<T, Policies>& x, const T& y)
 {
   return x.upper() != y || y != x.lower();
 }
 
 template<class T, class Policies> inline
-bool posne(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED bool posne(const T& x, const interval<T, Policies>& y)
 {
   return x != y.lower() || y.upper() != x;
 }

--- a/include/boost/numeric/interval/compare/lexicographic.hpp
+++ b/include/boost/numeric/interval/compare/lexicographic.hpp
@@ -20,96 +20,96 @@ namespace compare {
 namespace lexicographic {
 
 template<class T, class Policies1, class Policies2> inline
-bool operator<(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator<(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   const T& xl = x.lower();
   const T& yl = y.lower();
   return xl < yl || (xl == yl && x.upper() < y.upper());
 }
 
 template<class T, class Policies> inline
-bool operator<(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator<(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.lower() < y;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator<=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator<=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   const T& xl = x.lower();
   const T& yl = y.lower();
   return xl < yl || (xl == yl && x.upper() <= y.upper());
 }
 
 template<class T, class Policies> inline
-bool operator<=(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator<=(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   const T& xl = x.lower();
   return xl < y || (xl == y && x.upper() <= y);
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator>(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator>(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   const T& xl = x.lower();
   const T& yl = y.lower();
   return xl > yl || (xl == yl && x.upper() > y.upper());
 }
 
 template<class T, class Policies> inline
-bool operator>(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator>(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   const T& xl = x.lower();
   return xl > y || (xl == y && x.upper() > y);
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator>=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator>=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   const T& xl = x.lower();
   const T& yl = y.lower();
   return xl > yl || (xl == yl && x.upper() >= y.upper());
 }
 
 template<class T, class Policies> inline
-bool operator>=(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator>=(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.lower() >= y;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator==(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator==(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.lower() == y.lower() && x.upper() == y.upper();
 }
 
 template<class T, class Policies> inline
-bool operator==(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator==(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.lower() == y && x.upper() == y;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator!=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator!=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.lower() != y.lower() || x.upper() != y.upper();
 }
 
 template<class T, class Policies> inline
-bool operator!=(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator!=(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.lower() != y || x.upper() != y;
 }
 

--- a/include/boost/numeric/interval/compare/possible.hpp
+++ b/include/boost/numeric/interval/compare/possible.hpp
@@ -20,86 +20,86 @@ namespace compare {
 namespace possible {
 
 template<class T, class Policies1, class Policies2> inline
-bool operator<(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator<(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.lower() < y.upper();
 }
 
 template<class T, class Policies> inline
-bool operator<(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator<(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.lower() < y;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator<=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator<=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.lower() <= y.upper();
 }
 
 template<class T, class Policies> inline
-bool operator<=(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator<=(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.lower() <= y;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator>(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator>(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.upper() > y.lower();
 }
 
 template<class T, class Policies> inline
-bool operator>(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator>(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.upper() > y;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator>=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator>=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.upper() >= y.lower();
 }
 
 template<class T, class Policies> inline
-bool operator>=(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator>=(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.upper() >= y;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator==(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator==(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.lower() <= y.upper() && x.upper() >= y.lower();
 }
 
 template<class T, class Policies> inline
-bool operator==(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator==(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.lower() <= y && x.upper() >= y;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator!=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator!=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.lower() != y.upper() || x.upper() != y.lower();
 }
 
 template<class T, class Policies> inline
-bool operator!=(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED bool operator!=(const interval<T, Policies>& x, const T& y)
 {
-  if (detail::test_input(x, y)) throw comparison_error();
+  if (detail::test_input(x, y)) { comparison_error()(); }
   return x.lower() != y || x.upper() != y;
 }
 

--- a/include/boost/numeric/interval/compare/set.hpp
+++ b/include/boost/numeric/interval/compare/set.hpp
@@ -21,75 +21,81 @@ namespace compare {
 namespace set {
 
 template<class T, class Policies1, class Policies2> inline
-bool operator<(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator<(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return proper_subset(x, y);
 }
 
 template<class T, class Policies> inline
-bool operator<(const interval<T, Policies>& , const T& )
+BOOST_GPU_ENABLED bool operator<(const interval<T, Policies>& , const T& )
 {
-  throw comparison_error();
+  comparison_error()();
+  return false;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator<=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator<=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return subset(x, y);
 }
 
 template<class T, class Policies> inline
-bool operator<=(const interval<T, Policies>& , const T& )
+BOOST_GPU_ENABLED bool operator<=(const interval<T, Policies>& , const T& )
 {
-  throw comparison_error();
+  comparison_error()();
+  return false;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator>(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator>(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return proper_subset(y, x);
 }
 
 template<class T, class Policies> inline
-bool operator>(const interval<T, Policies>& , const T& )
+BOOST_GPU_ENABLED bool operator>(const interval<T, Policies>& , const T& )
 {
-  throw comparison_error();
+  comparison_error()();
+  return false;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator>=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator>=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return subset(y, x);
 }
 
 template<class T, class Policies> inline
-bool operator>=(const interval<T, Policies>& , const T& )
+BOOST_GPU_ENABLED bool operator>=(const interval<T, Policies>& , const T& )
 {
-  throw comparison_error();
+  comparison_error()();
+  return false;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator==(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator==(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return equal(y, x);
 }
 
 template<class T, class Policies> inline
-bool operator==(const interval<T, Policies>& , const T& )
+BOOST_GPU_ENABLED bool operator==(const interval<T, Policies>& , const T& )
 {
-  throw comparison_error();
+  comparison_error()();
+  return false;
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool operator!=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool operator!=(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   return !equal(y, x);
 }
 
 template<class T, class Policies> inline
-bool operator!=(const interval<T, Policies>& , const T& )
+BOOST_GPU_ENABLED bool operator!=(const interval<T, Policies>& , const T& )
 {
-  throw comparison_error();
+  comparison_error()();
+  return false;
 }
 
 } // namespace set

--- a/include/boost/numeric/interval/constants.hpp
+++ b/include/boost/numeric/interval/constants.hpp
@@ -24,38 +24,38 @@ static const float pi_f_u = 13176795.0f/(1<<22);
 static const double pi_d_l = (3373259426.0 + 273688.0 / (1<<21)) / (1<<30);
 static const double pi_d_u = (3373259426.0 + 273689.0 / (1<<21)) / (1<<30);
 
-template<class T> inline T pi_lower() { return 3; }
-template<class T> inline T pi_upper() { return 4; }
-template<class T> inline T pi_half_lower() { return 1; }
-template<class T> inline T pi_half_upper() { return 2; }
-template<class T> inline T pi_twice_lower() { return 6; }
-template<class T> inline T pi_twice_upper() { return 7; }
+template<class T> inline BOOST_GPU_ENABLED T pi_lower() { return 3; }
+template<class T> inline BOOST_GPU_ENABLED T pi_upper() { return 4; }
+template<class T> inline BOOST_GPU_ENABLED T pi_half_lower() { return 1; }
+template<class T> inline BOOST_GPU_ENABLED T pi_half_upper() { return 2; }
+template<class T> inline BOOST_GPU_ENABLED T pi_twice_lower() { return 6; }
+template<class T> inline BOOST_GPU_ENABLED T pi_twice_upper() { return 7; }
 
-template<> inline float pi_lower<float>() { return pi_f_l; }
-template<> inline float pi_upper<float>() { return pi_f_u; }
-template<> inline float pi_half_lower<float>() { return pi_f_l / 2; }
-template<> inline float pi_half_upper<float>() { return pi_f_u / 2; }
-template<> inline float pi_twice_lower<float>() { return pi_f_l * 2; }
-template<> inline float pi_twice_upper<float>() { return pi_f_u * 2; }
+template<> inline BOOST_GPU_ENABLED float pi_lower<float>() { return pi_f_l; }
+template<> inline BOOST_GPU_ENABLED float pi_upper<float>() { return pi_f_u; }
+template<> inline BOOST_GPU_ENABLED float pi_half_lower<float>() { return pi_f_l / 2; }
+template<> inline BOOST_GPU_ENABLED float pi_half_upper<float>() { return pi_f_u / 2; }
+template<> inline BOOST_GPU_ENABLED float pi_twice_lower<float>() { return pi_f_l * 2; }
+template<> inline BOOST_GPU_ENABLED float pi_twice_upper<float>() { return pi_f_u * 2; }
 
-template<> inline double pi_lower<double>() { return pi_d_l; }
-template<> inline double pi_upper<double>() { return pi_d_u; }
-template<> inline double pi_half_lower<double>() { return pi_d_l / 2; }
-template<> inline double pi_half_upper<double>() { return pi_d_u / 2; }
-template<> inline double pi_twice_lower<double>() { return pi_d_l * 2; }
-template<> inline double pi_twice_upper<double>() { return pi_d_u * 2; }
+template<> inline BOOST_GPU_ENABLED double pi_lower<double>() { return pi_d_l; }
+template<> inline BOOST_GPU_ENABLED double pi_upper<double>() { return pi_d_u; }
+template<> inline BOOST_GPU_ENABLED double pi_half_lower<double>() { return pi_d_l / 2; }
+template<> inline BOOST_GPU_ENABLED double pi_half_upper<double>() { return pi_d_u / 2; }
+template<> inline BOOST_GPU_ENABLED double pi_twice_lower<double>() { return pi_d_l * 2; }
+template<> inline BOOST_GPU_ENABLED double pi_twice_upper<double>() { return pi_d_u * 2; }
 
-template<> inline long double pi_lower<long double>() { return pi_d_l; }
-template<> inline long double pi_upper<long double>() { return pi_d_u; }
-template<> inline long double pi_half_lower<long double>() { return pi_d_l / 2; }
-template<> inline long double pi_half_upper<long double>() { return pi_d_u / 2; }
-template<> inline long double pi_twice_lower<long double>() { return pi_d_l * 2; }
-template<> inline long double pi_twice_upper<long double>() { return pi_d_u * 2; }
+template<> inline BOOST_GPU_ENABLED long double pi_lower<long double>() { return pi_d_l; }
+template<> inline BOOST_GPU_ENABLED long double pi_upper<long double>() { return pi_d_u; }
+template<> inline BOOST_GPU_ENABLED long double pi_half_lower<long double>() { return pi_d_l / 2; }
+template<> inline BOOST_GPU_ENABLED long double pi_half_upper<long double>() { return pi_d_u / 2; }
+template<> inline BOOST_GPU_ENABLED long double pi_twice_lower<long double>() { return pi_d_l * 2; }
+template<> inline BOOST_GPU_ENABLED long double pi_twice_upper<long double>() { return pi_d_u * 2; }
 
 } // namespace constants
 
 template<class I> inline
-I pi()
+BOOST_GPU_ENABLED I pi()
 {
   typedef typename I::base_type T;
   return I(constants::pi_lower<T>(),
@@ -63,7 +63,7 @@ I pi()
 }
 
 template<class I> inline
-I pi_half()
+BOOST_GPU_ENABLED I pi_half()
 {
   typedef typename I::base_type T;
   return I(constants::pi_half_lower<T>(),
@@ -71,7 +71,7 @@ I pi_half()
 }
 
 template<class I> inline
-I pi_twice()
+BOOST_GPU_ENABLED I pi_twice()
 {
   typedef typename I::base_type T;
   return I(constants::pi_twice_lower<T>(),

--- a/include/boost/numeric/interval/detail/bugs.hpp
+++ b/include/boost/numeric/interval/detail/bugs.hpp
@@ -45,4 +45,24 @@
 #  define BOOST_NUMERIC_INTERVAL_using_ahyp(a)
 #endif
 
+#if defined(__CUDACC__)
+#  define BOOST_GPU_DISABLED __host__
+#else
+#  define BOOST_GPU_DISABLED
+#endif
+
+#if defined(__CUDA_ARCH__)
+#  define BOOST_NUMERIC_INTERVAL_std(a) cuda::std::a
+#  undef BOOST_USING_STD_MIN
+#  define BOOST_USING_STD_MIN() using boost::numeric::gpu_spec::min
+#  undef BOOST_USING_STD_MAX
+#  define BOOST_USING_STD_MAX() using boost::numeric::gpu_spec::max
+#  define BOOST_NUMERIC_INTERVAL_throw(exception) printf("%s\n", exception); __trap()
+#else
+#  define BOOST_NUMERIC_INTERVAL_std(a) std::a
+#  define BOOST_NUMERIC_INTERVAL_throw(exception) throw std::runtime_error(exception)
+#endif
+
+#define BOOST_NUMERIC_INTERVAL_using_std(a) using BOOST_NUMERIC_INTERVAL_std(a)
+
 #endif // BOOST_NUMERIC_INTERVAL_DETAIL_BUGS

--- a/include/boost/numeric/interval/detail/c99sub_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/c99sub_rounding_control.hpp
@@ -40,4 +40,4 @@ struct c99_rounding_control
 } // namespace numeric
 } // namespace boost
 
-#endif // BOOST_NUMERIC_INTERVAL_DETAIL_C99SUB_ROUBDING_CONTROL_HPP
+#endif // BOOST_NUMERIC_INTERVAL_DETAIL_C99SUB_ROUNDING_CONTROL_HPP

--- a/include/boost/numeric/interval/detail/cuda_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/cuda_rounding_control.hpp
@@ -124,6 +124,10 @@ namespace detail {
   { return nextafter(x, CUDART_INF); }
   template <> inline __device__ double mid(const double &x, const double &y)
   { return __ddiv_rn(__dadd_rn(x, y), 2); }
+  template <> inline __device__ double conv_rd(const int &v)
+  { return __int2double_rn(v); }
+  template <> inline __device__ double conv_ru(const int &v)
+  { return __int2double_rn(v); }
   template <> inline __device__ double conv_rd(const long long int &v)
   { return __ll2double_rd(v); }
   template <> inline __device__ double conv_ru(const long long int &v)
@@ -170,8 +174,8 @@ template <class T, class Rounding>
 struct rounded_arith_direct : Rounding
 {
   __device__ void init() {}
-  template <class U> __device__ T conv_down(U const &v) { return detail::conv_rd(v); }
-  template <class U> __device__ T conv_up(U const &v) { return detail::conv_ru(v); }
+  template <class U> __device__ T conv_down(U const &v) { return detail::conv_rd<T>(v); }
+  template <class U> __device__ T conv_up(U const &v) { return detail::conv_ru<T>(v); }
   #define BOOST_NUMERIC_INTERVAL_new_func(a) \
     __device__ T a##_down(const T &x, const T &y) \
     { return detail::a##_rd(x, y); } \

--- a/include/boost/numeric/interval/detail/cuda_rounding_control.hpp
+++ b/include/boost/numeric/interval/detail/cuda_rounding_control.hpp
@@ -1,0 +1,261 @@
+/* Boost interval/detail/cuda_rounding_control.hpp file
+ *
+ * Copyright 2024 Lorenz Gillner
+ *
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or
+ * copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#ifndef BOOST_NUMERIC_INTERVAL_DETAIL_CUDA_ROUNDING_CONTROL_HPP
+#define BOOST_NUMERIC_INTERVAL_DETAIL_CUDA_ROUNDING_CONTROL_HPP
+
+#if !defined(__CUDACC__) && !defined(__NVCC__)
+#error Boost.Numeric.Interval: This header is intended for CUDA GPUs only.
+#endif
+
+#include <cuda.h>
+#include <math_constants.h>
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/climits>
+#include <cuda/std/utility>
+
+#include <boost/numeric/interval/checking.hpp>
+#include <boost/numeric/interval/rounding.hpp>
+
+namespace boost {
+namespace numeric {
+namespace gpu_spec {
+
+  /** templates */
+  template <class T> __device__ T min(const T &x, const T &y);
+  template <class T> __device__ T max(const T &x, const T &y);
+
+  /** float specialization */
+  template <> inline __device__ float min(const float &x, const float &y)
+  { return fminf(x, y); }
+  template <> inline __device__ float max(const float &x, const float &y)
+  { return fmaxf(x, y); }
+
+  /** double specialization */
+  template <> inline __device__ double min(const double &x, const double &y)
+  { return fmin(x, y); }
+  template <> inline __device__ double max(const double &x, const double &y)
+  { return fmax(x, y); }
+  
+} // namespace gpu_spec
+
+namespace interval_lib {
+
+namespace detail {
+
+  /** directed operation templates */
+  template <class T> __device__ T add_rd(const T &x, const T &y);
+  template <class T> __device__ T add_ru(const T &x, const T &y);
+  template <class T> __device__ T sub_rd(const T &x, const T &y);
+  template <class T> __device__ T sub_ru(const T &x, const T &y);
+  template <class T> __device__ T mul_rd(const T &x, const T &y);
+  template <class T> __device__ T mul_ru(const T &x, const T &y);
+  template <class T> __device__ T div_rd(const T &x, const T &y);
+  template <class T> __device__ T div_ru(const T &x, const T &y);
+  template <class T> __device__ T sqrt_rd(const T &x);
+  template <class T> __device__ T sqrt_ru(const T &x);
+  template <class T> __device__ T pred(const T &x);
+  template <class T> __device__ T succ(const T &x);
+  template <class T> __device__ T mid(const T &x, const T &y);
+
+  template <class T, class U> __device__ T conv_rd(U const &v);
+  template <class T, class U> __device__ T conv_ru(U const &v);
+
+  /** float specialization */
+  #define BOOST_NUMERIC_INTERVAL_gpu_spec(a) \
+    template <> inline __device__ float a##_rd(const float &x, const float &y) \
+    { return __f##a##_rd(x, y); } \
+    template <> inline __device__ float a##_ru(const float &x, const float &y) \
+    { return __f##a##_ru(x, y); }
+  BOOST_NUMERIC_INTERVAL_gpu_spec(add);
+  BOOST_NUMERIC_INTERVAL_gpu_spec(sub);
+  BOOST_NUMERIC_INTERVAL_gpu_spec(mul);
+  BOOST_NUMERIC_INTERVAL_gpu_spec(div);
+  #undef BOOST_NUMERIC_INTERVAL_gpu_spec
+  template <> inline __device__ float sqrt_rd(const float &x)
+  { return __fsqrt_rd(x); }
+  template <> inline __device__ float sqrt_ru(const float &x)
+  { return __fsqrt_ru(x); }
+  template <> inline __device__ float pred(const float &x)
+  { return nextafterf(x, -CUDART_INF_F); }
+  template <> inline __device__ float succ(const float &x)
+  { return nextafterf(x, CUDART_INF_F); }
+  template <> inline __device__ float mid(const float &x, const float &y)
+  { return __fdiv_rn(__fadd_rn(x, y), 2); }
+  template <> inline __device__ float conv_rd(const int &v)
+  { return __int2float_rd(v); }
+  template <> inline __device__ float conv_ru(const int &v)
+  { return __int2float_ru(v); }
+  template <> inline __device__ float conv_rd(const long long int &v)
+  { return __ll2float_rd(v); }
+  template <> inline __device__ float conv_ru(const long long int &v)
+  { return __ll2float_ru(v); }
+  template <> inline __device__ float conv_rd(const double &v)
+  { return __double2float_rd(v); }
+  template <> inline __device__ float conv_ru(const double &v)
+  { return __double2float_ru(v); }
+
+  /** double specialization */
+  #define BOOST_NUMERIC_INTERVAL_gpu_spec(a) \
+    template <> inline __device__ double a##_rd(const double &x, const double &y) \
+    { return __d##a##_rd(x, y); } \
+    template <> inline __device__ double a##_ru(const double &x, const double &y) \
+    { return __d##a##_ru(x, y); }
+  BOOST_NUMERIC_INTERVAL_gpu_spec(add);
+  BOOST_NUMERIC_INTERVAL_gpu_spec(sub);
+  BOOST_NUMERIC_INTERVAL_gpu_spec(mul);
+  BOOST_NUMERIC_INTERVAL_gpu_spec(div);
+  #undef BOOST_NUMERIC_INTERVAL_gpu_spec
+  template <> inline __device__ double sqrt_rd(const double &x)
+  { return __dsqrt_rd(x); }
+  template <> inline __device__ double sqrt_ru(const double &x)
+  { return __dsqrt_ru(x); }
+  template <> inline __device__ double pred(const double &x)
+  { return nextafter(x, -CUDART_INF); }
+  template <> inline __device__ double succ(const double &x)
+  { return nextafter(x, CUDART_INF); }
+  template <> inline __device__ double mid(const double &x, const double &y)
+  { return __ddiv_rn(__dadd_rn(x, y), 2); }
+  template <> inline __device__ double conv_rd(const long long int &v)
+  { return __ll2double_rd(v); }
+  template <> inline __device__ double conv_ru(const long long int &v)
+  { return __ll2double_ru(v); }
+
+} // namespace detail
+
+/**
+ * Checking should be compatible with the GPU "as is", so no further spezializations are needed
+ */
+
+template<class T>
+struct checking_base_gpu: checking_base<T>
+{};
+
+/**
+ * GPU rounding control
+ */
+
+template <class T>
+struct rounding_control_gpu: rounding_control<T>
+{};
+
+template <>
+struct rounding_control_gpu<float>
+{
+  __device__ float to_int(const float& x) { return nearbyintf(x); }
+};
+
+template <>
+struct rounding_control_gpu<double>
+{
+  __device__ double to_int(const double& x) { return nearbyint(x); }
+};
+
+/**
+ * Directly rounded arithmetic
+ */
+
+template<class T, class Rounding = rounding_control<T> >
+struct rounded_arith_direct;
+
+template <class T, class Rounding>
+struct rounded_arith_direct : Rounding
+{
+  __device__ void init() {}
+  template <class U> __device__ T conv_down(U const &v) { return detail::conv_rd(v); }
+  template <class U> __device__ T conv_up(U const &v) { return detail::conv_ru(v); }
+  #define BOOST_NUMERIC_INTERVAL_new_func(a) \
+    __device__ T a##_down(const T &x, const T &y) \
+    { return detail::a##_rd(x, y); } \
+    __device__ T a##_up(const T &x, const T &y) \
+    { return detail::a##_ru(x, y); }
+  BOOST_NUMERIC_INTERVAL_new_func(add);
+  BOOST_NUMERIC_INTERVAL_new_func(sub);
+  BOOST_NUMERIC_INTERVAL_new_func(mul);
+  BOOST_NUMERIC_INTERVAL_new_func(div);
+  #undef BOOST_NUMERIC_INTERVAL_new_func
+  __device__ T sqrt_down(const T &x) { return detail::sqrt_rd(x); }
+  __device__ T sqrt_up(const T &x)   { return detail::sqrt_ru(x); }
+  __device__ T median(const T &x, const T &y) { return detail::mid(x, y); }
+  __device__ T int_down(const T &x) { BOOST_NUMERIC_INTERVAL_using_math(floor); return floor(x); }
+  __device__ T int_up(const T &x)   { BOOST_NUMERIC_INTERVAL_using_math(ceil); return ceil(x); }
+  __device__ T next_down(const T &x) { return detail::pred(x); }
+  __device__ T next_up(const T &x)   { return detail::succ(x); }
+};
+
+/**
+ * Rounded transcendental functions
+ */
+
+template<class T, class Rounding = rounded_arith_direct<T> > 
+struct rounded_transc_direct;
+
+template <class T, class Rounding>
+struct rounded_transc_direct: Rounding
+{
+  #define BOOST_NUMERIC_INTERVAL_new_func(a) \
+    __device__ T a##_down(const T& x) \
+    { BOOST_NUMERIC_INTERVAL_using_math(a); T ax = a(x); return (ax > T(-1) && ax != T(0)) ? next_down(ax) : ax; } \
+    __device__ T a##_up  (const T& x) \
+    { BOOST_NUMERIC_INTERVAL_using_math(a); T ax = a(x); return (ax < T(1) && ax != T(0)) ? next_up(ax) : ax; }
+  BOOST_NUMERIC_INTERVAL_new_func(exp)   // 1 ulp (double)
+  BOOST_NUMERIC_INTERVAL_new_func(log)   // 1 ulp (double)
+  BOOST_NUMERIC_INTERVAL_new_func(sin)   // 2 ulp (double)
+  BOOST_NUMERIC_INTERVAL_new_func(cos)   // 2 ulp (double)
+  BOOST_NUMERIC_INTERVAL_new_func(tan)   // 2 ulp (double)
+  BOOST_NUMERIC_INTERVAL_new_func(asin)  // 2 ulp (double)
+  BOOST_NUMERIC_INTERVAL_new_func(acos)  // 2 ulp (double)
+  BOOST_NUMERIC_INTERVAL_new_func(atan)  // 2 ulp (double)
+  BOOST_NUMERIC_INTERVAL_new_func(sinh)  // 2 ulp (double)
+  BOOST_NUMERIC_INTERVAL_new_func(cosh)  // 1 ulp (double)
+  BOOST_NUMERIC_INTERVAL_new_func(tanh)  // 1 ulp (double)
+  BOOST_NUMERIC_INTERVAL_new_func(asinh) // 3 ulp (double)
+  BOOST_NUMERIC_INTERVAL_new_func(acosh) // 3 ulp (double)
+  BOOST_NUMERIC_INTERVAL_new_func(atanh) // 2 ulp (double)
+  #undef BOOST_NUMERIC_INTERVAL_new_func
+};
+
+/** 
+ * Convenience wrappers for GPU use
+ */
+
+template <class T>
+struct rounded_arith_gpu: rounded_arith_direct<T>
+{};
+
+template <class T>
+struct rounded_transc_gpu: rounded_transc_direct<T>
+{};
+
+/* fall back to exact mode if no specialization is available */
+template <class T>
+struct rounded_math_gpu: save_state_nothing<rounded_arith_exact<T> >
+{};
+
+template <>
+struct rounded_math_gpu<float>: save_state_nothing<rounded_arith_gpu<float> >
+{};
+
+template <>
+struct rounded_math_gpu<double>: save_state_nothing<rounded_arith_gpu<double> >
+{};
+
+template<class T>
+struct default_policies_gpu
+{
+  typedef policies<rounded_math_gpu<T>, checking_base_gpu<T> > type;
+};
+
+} // namespace interval_lib
+} // namespace numeric
+} // namespace boost
+
+#endif /* BOOST_NUMERIC_INTERVAL_DETAIL_CUDA_ROUNDING_CONTROL_HPP */

--- a/include/boost/numeric/interval/detail/division.hpp
+++ b/include/boost/numeric/interval/detail/division.hpp
@@ -22,8 +22,8 @@ namespace interval_lib {
 namespace detail {
 
 template<class T, class Policies> inline
-interval<T, Policies> div_non_zero(const interval<T, Policies>& x,
-                                   const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> div_non_zero(const interval<T, Policies>& x,
+                                                     const interval<T, Policies>& y)
 {
   // assert(!in_zero(y));
   typename Policies::rounding rnd;
@@ -50,7 +50,7 @@ interval<T, Policies> div_non_zero(const interval<T, Policies>& x,
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> div_non_zero(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> div_non_zero(const T& x, const interval<T, Policies>& y)
 {
   // assert(!in_zero(y));
   typename Policies::rounding rnd;
@@ -64,7 +64,7 @@ interval<T, Policies> div_non_zero(const T& x, const interval<T, Policies>& y)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> div_positive(const interval<T, Policies>& x, const T& yu)
+BOOST_GPU_ENABLED interval<T, Policies> div_positive(const interval<T, Policies>& x, const T& yu)
 {
   // assert(::boost::numeric::interval_lib::user::is_pos(yu));
   if (::boost::numeric::interval_lib::user::is_zero(x.lower()) &&
@@ -84,7 +84,7 @@ interval<T, Policies> div_positive(const interval<T, Policies>& x, const T& yu)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> div_positive(const T& x, const T& yu)
+BOOST_GPU_ENABLED interval<T, Policies> div_positive(const T& x, const T& yu)
 {
   // assert(::boost::numeric::interval_lib::user::is_pos(yu));
   typedef interval<T, Policies> I;
@@ -99,7 +99,7 @@ interval<T, Policies> div_positive(const T& x, const T& yu)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> div_negative(const interval<T, Policies>& x, const T& yl)
+BOOST_GPU_ENABLED interval<T, Policies> div_negative(const interval<T, Policies>& x, const T& yl)
 {
   // assert(::boost::numeric::interval_lib::user::is_neg(yl));
   if (::boost::numeric::interval_lib::user::is_zero(x.lower()) &&
@@ -119,7 +119,7 @@ interval<T, Policies> div_negative(const interval<T, Policies>& x, const T& yl)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> div_negative(const T& x, const T& yl)
+BOOST_GPU_ENABLED interval<T, Policies> div_negative(const T& x, const T& yl)
 {
   // assert(::boost::numeric::interval_lib::user::is_neg(yl));
   typedef interval<T, Policies> I;
@@ -134,7 +134,7 @@ interval<T, Policies> div_negative(const T& x, const T& yl)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> div_zero(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> div_zero(const interval<T, Policies>& x)
 {
   if (::boost::numeric::interval_lib::user::is_zero(x.lower()) &&
       ::boost::numeric::interval_lib::user::is_zero(x.upper()))
@@ -143,7 +143,7 @@ interval<T, Policies> div_zero(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> div_zero(const T& x)
+BOOST_GPU_ENABLED interval<T, Policies> div_zero(const T& x)
 {
   if (::boost::numeric::interval_lib::user::is_zero(x))
     return interval<T, Policies>(static_cast<T>(0), static_cast<T>(0), true);
@@ -151,7 +151,7 @@ interval<T, Policies> div_zero(const T& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> div_zero_part1(const interval<T, Policies>& x,
+BOOST_GPU_ENABLED interval<T, Policies> div_zero_part1(const interval<T, Policies>& x,
                                      const interval<T, Policies>& y, bool& b)
 {
   // assert(::boost::numeric::interval_lib::user::is_neg(y.lower()) && ::boost::numeric::interval_lib::user::is_pos(y.upper()));
@@ -173,8 +173,8 @@ interval<T, Policies> div_zero_part1(const interval<T, Policies>& x,
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> div_zero_part2(const interval<T, Policies>& x,
-                                     const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> div_zero_part2(const interval<T, Policies>& x,
+                                                       const interval<T, Policies>& y)
 {
   // assert(::boost::numeric::interval_lib::user::is_neg(y.lower()) && ::boost::numeric::interval_lib::user::is_pos(y.upper()) && (div_zero_part1(x, y, b), b));
   typename Policies::rounding rnd;

--- a/include/boost/numeric/interval/detail/interval_prototype.hpp
+++ b/include/boost/numeric/interval/detail/interval_prototype.hpp
@@ -10,6 +10,8 @@
 #ifndef BOOST_NUMERIC_INTERVAL_DETAIL_INTERVAL_PROTOTYPE_HPP
 #define BOOST_NUMERIC_INTERVAL_DETAIL_INTERVAL_PROTOTYPE_HPP
 
+#include <boost/numeric/interval/detail/bugs.hpp>
+
 namespace boost {
 namespace numeric {
 

--- a/include/boost/numeric/interval/detail/test_input.hpp
+++ b/include/boost/numeric/interval/detail/test_input.hpp
@@ -17,53 +17,53 @@ namespace numeric {
 namespace interval_lib {
 namespace user {
 
-template<class T> inline
-bool is_zero(T const &v) { return v == static_cast<T>(0); }
+template<class T>
+BOOST_GPU_ENABLED bool is_zero(T const &v) { return v == static_cast<T>(0); }
 
-template<class T> inline
-bool is_neg (T const &v) { return v <  static_cast<T>(0); }
+template<class T>
+BOOST_GPU_ENABLED bool is_neg (T const &v) { return v <  static_cast<T>(0); }
 
-template<class T> inline
-bool is_pos (T const &v) { return v >  static_cast<T>(0); }
+template<class T>
+BOOST_GPU_ENABLED bool is_pos (T const &v) { return v >  static_cast<T>(0); }
 
 } // namespace user
 
 namespace detail {
 
-template<class T, class Policies> inline
-bool test_input(const interval<T, Policies>& x) {
+template<class T, class Policies>
+BOOST_GPU_ENABLED bool test_input(const interval<T, Policies>& x) {
   typedef typename Policies::checking checking;
   return checking::is_empty(x.lower(), x.upper());
 }
 
-template<class T, class Policies1, class Policies2> inline
-bool test_input(const interval<T, Policies1>& x, const interval<T, Policies2>& y) {
+template<class T, class Policies1, class Policies2>
+BOOST_GPU_ENABLED bool test_input(const interval<T, Policies1>& x, const interval<T, Policies2>& y) {
   typedef typename Policies1::checking checking1;
   typedef typename Policies2::checking checking2;
   return checking1::is_empty(x.lower(), x.upper()) ||
          checking2::is_empty(y.lower(), y.upper());
 }
 
-template<class T, class Policies> inline
-bool test_input(const T& x, const interval<T, Policies>& y) {
+template<class T, class Policies>
+BOOST_GPU_ENABLED bool test_input(const T& x, const interval<T, Policies>& y) {
   typedef typename Policies::checking checking;
   return checking::is_nan(x) || checking::is_empty(y.lower(), y.upper());
 }
 
-template<class T, class Policies> inline
-bool test_input(const interval<T, Policies>& x, const T& y) {
+template<class T, class Policies>
+BOOST_GPU_ENABLED bool test_input(const interval<T, Policies>& x, const T& y) {
   typedef typename Policies::checking checking;
   return checking::is_empty(x.lower(), x.upper()) || checking::is_nan(y);
 }
 
-template<class T, class Policies> inline
-bool test_input(const T& x) {
+template<class T, class Policies>
+BOOST_GPU_ENABLED bool test_input(const T& x) {
   typedef typename Policies::checking checking;
   return checking::is_nan(x);
 }
 
-template<class T, class Policies> inline
-bool test_input(const T& x, const T& y) {
+template<class T, class Policies>
+BOOST_GPU_ENABLED bool test_input(const T& x, const T& y) {
   typedef typename Policies::checking checking;
   return checking::is_nan(x) || checking::is_nan(y);
 }

--- a/include/boost/numeric/interval/ext/integer.hpp
+++ b/include/boost/numeric/interval/ext/integer.hpp
@@ -17,49 +17,49 @@ namespace boost {
 namespace numeric {
 
 template<class T, class Policies> inline
-interval<T, Policies> operator+ (const interval<T, Policies>& x, int y)
+BOOST_GPU_ENABLED interval<T, Policies> operator+ (const interval<T, Policies>& x, int y)
 {
   return x + static_cast<T>(y);
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator+ (int x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> operator+ (int x, const interval<T, Policies>& y)
 {
   return static_cast<T>(x) + y;
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator- (const interval<T, Policies>& x, int y)
+BOOST_GPU_ENABLED interval<T, Policies> operator- (const interval<T, Policies>& x, int y)
 {
   return x - static_cast<T>(y);
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator- (int x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> operator- (int x, const interval<T, Policies>& y)
 {
   return static_cast<T>(x) - y;
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator* (const interval<T, Policies>& x, int y)
+BOOST_GPU_ENABLED interval<T, Policies> operator* (const interval<T, Policies>& x, int y)
 {
   return x * static_cast<T>(y);
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator* (int x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> operator* (int x, const interval<T, Policies>& y)
 {
   return static_cast<T>(x) * y;
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator/ (const interval<T, Policies>& x, int y)
+BOOST_GPU_ENABLED interval<T, Policies> operator/ (const interval<T, Policies>& x, int y)
 {
   return x / static_cast<T>(y);
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> operator/ (int x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> operator/ (int x, const interval<T, Policies>& y)
 {
   return static_cast<T>(x) / y;
 }

--- a/include/boost/numeric/interval/hw_rounding.hpp
+++ b/include/boost/numeric/interval/hw_rounding.hpp
@@ -34,6 +34,10 @@
 #  include <boost/numeric/interval/detail/ia64_rounding_control.hpp>
 #endif
 
+#if defined(__CUDACC__) || defined(__NVCC__)
+#  include <boost/numeric/interval/detail/cuda_rounding_control.hpp>
+#endif
+
 #if defined(BOOST_NUMERIC_INTERVAL_NO_HARDWARE) && !defined(BOOST_NO_FENV_H)
 #  include <boost/numeric/interval/detail/c99_rounding_control.hpp>
 #endif

--- a/include/boost/numeric/interval/interval.hpp
+++ b/include/boost/numeric/interval/interval.hpp
@@ -18,14 +18,13 @@ namespace boost {
 namespace numeric {
 
 namespace interval_lib {
-    
-class comparison_error
-  : public std::runtime_error 
+
+struct comparison_error
 {
-public:
-  comparison_error()
-    : std::runtime_error("boost::interval: uncertain comparison")
-  { }
+  BOOST_GPU_ENABLED void operator()()
+  {
+    BOOST_NUMERIC_INTERVAL_throw("boost::interval: uncertain comparison");
+  }
 };
 
 } // namespace interval_lib
@@ -44,69 +43,76 @@ public:
   typedef T base_type;
   typedef Policies traits_type;
 
-  T const &lower() const;
-  T const &upper() const;
+  BOOST_GPU_ENABLED T const &lower() const;
+  BOOST_GPU_ENABLED T const &upper() const;
 
-  interval();
-  interval(T const &v);
-  template<class T1> interval(T1 const &v);
-  interval(T const &l, T const &u);
-  template<class T1, class T2> interval(T1 const &l, T2 const &u);
-  interval(interval<T, Policies> const &r);
-  template<class Policies1> interval(interval<T, Policies1> const &r);
-  template<class T1, class Policies1> interval(interval<T1, Policies1> const &r);
+  BOOST_GPU_ENABLED interval();
+  BOOST_GPU_ENABLED interval(T const &v);
+  template<class T1>
+  BOOST_GPU_ENABLED interval(T1 const &v);
+  BOOST_GPU_ENABLED interval(T const &l, T const &u);
+  template<class T1, class T2>
+  BOOST_GPU_ENABLED interval(T1 const &l, T2 const &u);
+  BOOST_GPU_ENABLED interval(interval<T, Policies> const &r);
+  template<class Policies1>
+  BOOST_GPU_ENABLED interval(interval<T, Policies1> const &r);
+  template<class T1, class Policies1>
+  BOOST_GPU_ENABLED interval(interval<T1, Policies1> const &r);
 
-  interval &operator=(T const &v);
-  template<class T1> interval &operator=(T1 const &v);
-  interval &operator=(interval<T, Policies> const &r);
-  template<class Policies1> interval &operator=(interval<T, Policies1> const &r);
-  template<class T1, class Policies1> interval &operator=(interval<T1, Policies1> const &r);
- 
-  void assign(const T& l, const T& u);
+  BOOST_GPU_ENABLED interval &operator=(T const &v);
+  template<class T1>
+  BOOST_GPU_ENABLED interval &operator=(T1 const &v);
+  BOOST_GPU_ENABLED interval &operator=(interval<T, Policies> const &r);
+  template<class Policies1>
+  BOOST_GPU_ENABLED interval &operator=(interval<T, Policies1> const &r);
+  template<class T1, class Policies1>
+  BOOST_GPU_ENABLED interval &operator=(interval<T1, Policies1> const &r);
 
-  static interval empty();
-  static interval whole();
-  static interval hull(const T& x, const T& y);
+  BOOST_GPU_ENABLED void assign(const T& l, const T& u);
 
-  interval& operator+= (const T& r);
-  interval& operator+= (const interval& r);
-  interval& operator-= (const T& r);
-  interval& operator-= (const interval& r);
-  interval& operator*= (const T& r);
-  interval& operator*= (const interval& r);
-  interval& operator/= (const T& r);
-  interval& operator/= (const interval& r);
+  BOOST_GPU_ENABLED static interval empty();
+  BOOST_GPU_ENABLED static interval whole();
+  BOOST_GPU_ENABLED static interval hull(const T& x, const T& y);
 
-  bool operator< (const interval_holder& r) const;
-  bool operator> (const interval_holder& r) const;
-  bool operator<= (const interval_holder& r) const;
-  bool operator>= (const interval_holder& r) const;
-  bool operator== (const interval_holder& r) const;
-  bool operator!= (const interval_holder& r) const;
+  BOOST_GPU_ENABLED interval& operator+= (const T& r);
+  BOOST_GPU_ENABLED interval& operator+= (const interval& r);
+  BOOST_GPU_ENABLED interval& operator-= (const T& r);
+  BOOST_GPU_ENABLED interval& operator-= (const interval& r);
+  BOOST_GPU_ENABLED interval& operator*= (const T& r);
+  BOOST_GPU_ENABLED interval& operator*= (const interval& r);
+  BOOST_GPU_ENABLED interval& operator/= (const T& r);
+  BOOST_GPU_ENABLED interval& operator/= (const interval& r);
 
-  bool operator< (const number_holder& r) const;
-  bool operator> (const number_holder& r) const;
-  bool operator<= (const number_holder& r) const;
-  bool operator>= (const number_holder& r) const;
-  bool operator== (const number_holder& r) const;
-  bool operator!= (const number_holder& r) const;
+  BOOST_GPU_ENABLED bool operator< (const interval_holder& r) const;
+  BOOST_GPU_ENABLED bool operator> (const interval_holder& r) const;
+  BOOST_GPU_ENABLED bool operator<= (const interval_holder& r) const;
+  BOOST_GPU_ENABLED bool operator>= (const interval_holder& r) const;
+  BOOST_GPU_ENABLED bool operator== (const interval_holder& r) const;
+  BOOST_GPU_ENABLED bool operator!= (const interval_holder& r) const;
+
+  BOOST_GPU_ENABLED bool operator< (const number_holder& r) const;
+  BOOST_GPU_ENABLED bool operator> (const number_holder& r) const;
+  BOOST_GPU_ENABLED bool operator<= (const number_holder& r) const;
+  BOOST_GPU_ENABLED bool operator>= (const number_holder& r) const;
+  BOOST_GPU_ENABLED bool operator== (const number_holder& r) const;
+  BOOST_GPU_ENABLED bool operator!= (const number_holder& r) const;
 
   // the following is for internal use only, it is not a published interface
   // nevertheless, it's public because friends don't always work correctly.
-  interval(const T& l, const T& u, bool): low(l), up(u) {}
-  void set_empty();
-  void set_whole();
-  void set(const T& l, const T& u);
+  BOOST_GPU_ENABLED interval(const T& l, const T& u, bool): low(l), up(u) {}
+  BOOST_GPU_ENABLED void set_empty();
+  BOOST_GPU_ENABLED void set_whole();
+  BOOST_GPU_ENABLED void set(const T& l, const T& u);
 
 private:
   struct interval_holder {
     template<class Policies2>
-    interval_holder(const interval<T, Policies2>& r)
+    BOOST_GPU_ENABLED interval_holder(const interval<T, Policies2>& r)
       : low(r.lower()), up(r.upper())
     {
       typedef typename Policies2::checking checking2;
       if (checking2::is_empty(low, up))
-        throw interval_lib::comparison_error();
+        interval_lib::comparison_error()();
     }
 
     const T& low;
@@ -114,11 +120,11 @@ private:
   };
 
   struct number_holder {
-    number_holder(const T& r) : val(r)
+    BOOST_GPU_ENABLED number_holder(const T& r) : val(r)
     {
       typedef typename Policies::checking checking;
       if (checking::is_nan(r))
-        throw interval_lib::comparison_error();
+        interval_lib::comparison_error()();
     }
     
     const T& val;
@@ -132,18 +138,18 @@ private:
 };
 
 template<class T, class Policies> inline
-interval<T, Policies>::interval():
+BOOST_GPU_ENABLED interval<T, Policies>::interval():
   low(static_cast<T>(0)), up(static_cast<T>(0))
 {}
 
 template<class T, class Policies> inline
-interval<T, Policies>::interval(T const &v): low(v), up(v)
+BOOST_GPU_ENABLED interval<T, Policies>::interval(T const &v): low(v), up(v)
 {
   if (checking::is_nan(v)) set_empty();
 }
 
 template<class T, class Policies> template<class T1> inline
-interval<T, Policies>::interval(T1 const &v)
+BOOST_GPU_ENABLED interval<T, Policies>::interval(T1 const &v)
 {
   if (checking::is_nan(v)) set_empty();
   else {
@@ -154,7 +160,7 @@ interval<T, Policies>::interval(T1 const &v)
 }
 
 template<class T, class Policies> template<class T1, class T2> inline
-interval<T, Policies>::interval(T1 const &l, T2 const &u)
+BOOST_GPU_ENABLED interval<T, Policies>::interval(T1 const &l, T2 const &u)
 {
   if (checking::is_nan(l) || checking::is_nan(u) || !(l <= u)) set_empty();
   else {
@@ -165,7 +171,7 @@ interval<T, Policies>::interval(T1 const &l, T2 const &u)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies>::interval(T const &l, T const &u): low(l), up(u)
+BOOST_GPU_ENABLED interval<T, Policies>::interval(T const &l, T const &u): low(l), up(u)
 {
   if (checking::is_nan(l) || checking::is_nan(u) || !(l <= u))
     set_empty();
@@ -173,18 +179,18 @@ interval<T, Policies>::interval(T const &l, T const &u): low(l), up(u)
 
 
 template<class T, class Policies> inline
-interval<T, Policies>::interval(interval<T, Policies> const &r): low(r.lower()), up(r.upper())
+BOOST_GPU_ENABLED interval<T, Policies>::interval(interval<T, Policies> const &r): low(r.lower()), up(r.upper())
 {}
 
 template<class T, class Policies> template<class Policies1> inline
-interval<T, Policies>::interval(interval<T, Policies1> const &r): low(r.lower()), up(r.upper())
+BOOST_GPU_ENABLED interval<T, Policies>::interval(interval<T, Policies1> const &r): low(r.lower()), up(r.upper())
 {
   typedef typename Policies1::checking checking1;
   if (checking1::is_empty(r.lower(), r.upper())) set_empty();
 }
 
 template<class T, class Policies> template<class T1, class Policies1> inline
-interval<T, Policies>::interval(interval<T1, Policies1> const &r)
+BOOST_GPU_ENABLED interval<T, Policies>::interval(interval<T1, Policies1> const &r)
 {
   typedef typename Policies1::checking checking1;
   if (checking1::is_empty(r.lower(), r.upper())) set_empty();
@@ -196,7 +202,7 @@ interval<T, Policies>::interval(interval<T1, Policies1> const &r)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> &interval<T, Policies>::operator=(T const &v)
+BOOST_GPU_ENABLED interval<T, Policies> &interval<T, Policies>::operator=(T const &v)
 {
   if (checking::is_nan(v)) set_empty();
   else low = up = v;
@@ -204,7 +210,7 @@ interval<T, Policies> &interval<T, Policies>::operator=(T const &v)
 }
 
 template<class T, class Policies> template<class T1> inline
-interval<T, Policies> &interval<T, Policies>::operator=(T1 const &v)
+BOOST_GPU_ENABLED interval<T, Policies> &interval<T, Policies>::operator=(T1 const &v)
 {
   if (checking::is_nan(v)) set_empty();
   else {
@@ -216,7 +222,7 @@ interval<T, Policies> &interval<T, Policies>::operator=(T1 const &v)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> &interval<T, Policies>::operator=(interval<T, Policies> const &r)
+BOOST_GPU_ENABLED interval<T, Policies> &interval<T, Policies>::operator=(interval<T, Policies> const &r)
 {
   low = r.lower();
   up  = r.upper();
@@ -224,7 +230,7 @@ interval<T, Policies> &interval<T, Policies>::operator=(interval<T, Policies> co
 }
 
 template<class T, class Policies> template<class Policies1> inline
-interval<T, Policies> &interval<T, Policies>::operator=(interval<T, Policies1> const &r)
+BOOST_GPU_ENABLED interval<T, Policies> &interval<T, Policies>::operator=(interval<T, Policies1> const &r)
 {
   typedef typename Policies1::checking checking1;
   if (checking1::is_empty(r.lower(), r.upper())) set_empty();
@@ -236,7 +242,7 @@ interval<T, Policies> &interval<T, Policies>::operator=(interval<T, Policies1> c
 }
 
 template<class T, class Policies> template<class T1, class Policies1> inline
-interval<T, Policies> &interval<T, Policies>::operator=(interval<T1, Policies1> const &r)
+BOOST_GPU_ENABLED interval<T, Policies> &interval<T, Policies>::operator=(interval<T1, Policies1> const &r)
 {
   typedef typename Policies1::checking checking1;
   if (checking1::is_empty(r.lower(), r.upper())) set_empty();
@@ -249,7 +255,7 @@ interval<T, Policies> &interval<T, Policies>::operator=(interval<T1, Policies1> 
 }
 
 template<class T, class Policies> inline
-void interval<T, Policies>::assign(const T& l, const T& u)
+BOOST_GPU_ENABLED void interval<T, Policies>::assign(const T& l, const T& u)
 {
   if (checking::is_nan(l) || checking::is_nan(u) || !(l <= u))
     set_empty();
@@ -257,28 +263,28 @@ void interval<T, Policies>::assign(const T& l, const T& u)
 }
 
 template<class T, class Policies> inline
-void interval<T, Policies>::set(const T& l, const T& u)
+BOOST_GPU_ENABLED void interval<T, Policies>::set(const T& l, const T& u)
 {
   low = l;
   up  = u;
 }
 
 template<class T, class Policies> inline
-void interval<T, Policies>::set_empty()
+BOOST_GPU_ENABLED void interval<T, Policies>::set_empty()
 {
   low = checking::empty_lower();
   up  = checking::empty_upper();
 }
 
 template<class T, class Policies> inline
-void interval<T, Policies>::set_whole()
+BOOST_GPU_ENABLED void interval<T, Policies>::set_whole()
 {
   low = checking::neg_inf();
   up  = checking::pos_inf();
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> interval<T, Policies>::hull(const T& x, const T& y)
+BOOST_GPU_ENABLED interval<T, Policies> interval<T, Policies>::hull(const T& x, const T& y)
 {
   bool bad_x = checking::is_nan(x);
   bool bad_y = checking::is_nan(y);
@@ -292,26 +298,26 @@ interval<T, Policies> interval<T, Policies>::hull(const T& x, const T& y)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> interval<T, Policies>::empty()
+BOOST_GPU_ENABLED interval<T, Policies> interval<T, Policies>::empty()
 {
   return interval<T, Policies>(checking::empty_lower(),
                                checking::empty_upper(), true);
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> interval<T, Policies>::whole()
+BOOST_GPU_ENABLED interval<T, Policies> interval<T, Policies>::whole()
 {
   return interval<T, Policies>(checking::neg_inf(), checking::pos_inf(), true);
 }
 
 template<class T, class Policies> inline
-const T& interval<T, Policies>::lower() const
+BOOST_GPU_ENABLED const T& interval<T, Policies>::lower() const
 {
   return low;
 }
 
 template<class T, class Policies> inline
-const T& interval<T, Policies>::upper() const
+BOOST_GPU_ENABLED const T& interval<T, Policies>::upper() const
 {
   return up;
 }
@@ -321,63 +327,69 @@ const T& interval<T, Policies>::upper() const
  */
 
 template<class T, class Policies> inline
-bool interval<T, Policies>::operator< (const interval_holder& r) const
+BOOST_GPU_ENABLED bool interval<T, Policies>::operator< (const interval_holder& r) const
 {
   if (!checking::is_empty(low, up)) {
     if (up < r.low) return true;
     else if (low >= r.up) return false;
   }
-  throw interval_lib::comparison_error();
+  interval_lib::comparison_error()();
+  return false; // never reached
 }
 
 template<class T, class Policies> inline
-bool interval<T, Policies>::operator> (const interval_holder& r) const
+BOOST_GPU_ENABLED bool interval<T, Policies>::operator> (const interval_holder& r) const
 {
   if (!checking::is_empty(low, up)) {
     if (low > r.up) return true;
     else if (up <= r.low) return false;
   }
-  throw interval_lib::comparison_error();
+  interval_lib::comparison_error()();
+  return false; // never reached
 }
 
 template<class T, class Policies> inline
-bool interval<T, Policies>::operator<= (const interval_holder& r) const
+BOOST_GPU_ENABLED bool interval<T, Policies>::operator<= (const interval_holder& r) const
 {
   if (!checking::is_empty(low, up)) {
     if (up <= r.low) return true;
     else if (low > r.up) return false;
   }
-  throw interval_lib::comparison_error();
+  interval_lib::comparison_error()();
+  return false; // never reached
 }
 
 template<class T, class Policies> inline
-bool interval<T, Policies>::operator>= (const interval_holder& r) const
+BOOST_GPU_ENABLED bool interval<T, Policies>::operator>= (const interval_holder& r) const
 {
   if (!checking::is_empty(low, up)) {
     if (low >= r.up) return true;
     else if (up < r.low) return false;
   }
-  throw interval_lib::comparison_error();
+  interval_lib::comparison_error()();
+  return false; // never reached
 }
 
 template<class T, class Policies> inline
-bool interval<T, Policies>::operator== (const interval_holder& r) const
+BOOST_GPU_ENABLED bool interval<T, Policies>::operator== (const interval_holder& r) const
 {
   if (!checking::is_empty(low, up)) {
     if (up == r.low && low == r.up) return true;
     else if (up < r.low || low > r.up) return false;
   }
-  throw interval_lib::comparison_error();
+  interval_lib::comparison_error()();
+  return false; // never reached
 }
 
 template<class T, class Policies> inline
-bool interval<T, Policies>::operator!= (const interval_holder& r) const
+BOOST_GPU_ENABLED bool interval<T, Policies>::operator!= (const interval_holder& r) const
 {
   if (!checking::is_empty(low, up)) {
     if (up < r.low || low > r.up) return true;
     else if (up == r.low && low == r.up) return false;
   }
-  throw interval_lib::comparison_error();
+  interval_lib::comparison_error()();
+  return false; // never reached
 }
 
 /*
@@ -385,63 +397,69 @@ bool interval<T, Policies>::operator!= (const interval_holder& r) const
  */
 
 template<class T, class Policies> inline
-bool interval<T, Policies>::operator< (const number_holder& r) const
+BOOST_GPU_ENABLED bool interval<T, Policies>::operator< (const number_holder& r) const
 {
   if (!checking::is_empty(low, up)) {
     if (up < r.val) return true;
     else if (low >= r.val) return false;
   }
-  throw interval_lib::comparison_error();
+  interval_lib::comparison_error()();
+  return false; // never reached
 }
 
 template<class T, class Policies> inline
-bool interval<T, Policies>::operator> (const number_holder& r) const
+BOOST_GPU_ENABLED bool interval<T, Policies>::operator> (const number_holder& r) const
 {
   if (!checking::is_empty(low, up)) {
     if (low > r.val) return true;
     else if (up <= r.val) return false;
   }
-  throw interval_lib::comparison_error();
+  interval_lib::comparison_error()();
+  return false; // never reached
 }
 
 template<class T, class Policies> inline
-bool interval<T, Policies>::operator<= (const number_holder& r) const
+BOOST_GPU_ENABLED bool interval<T, Policies>::operator<= (const number_holder& r) const
 {
   if (!checking::is_empty(low, up)) {
     if (up <= r.val) return true;
     else if (low > r.val) return false;
   }
-  throw interval_lib::comparison_error();
+  interval_lib::comparison_error()();
+  return false; // never reached
 }
 
 template<class T, class Policies> inline
-bool interval<T, Policies>::operator>= (const number_holder& r) const
+BOOST_GPU_ENABLED bool interval<T, Policies>::operator>= (const number_holder& r) const
 {
   if (!checking::is_empty(low, up)) {
     if (low >= r.val) return true;
     else if (up < r.val) return false;
   }
-  throw interval_lib::comparison_error();
+  interval_lib::comparison_error()();
+  return false; // never reached
 }
 
 template<class T, class Policies> inline
-bool interval<T, Policies>::operator== (const number_holder& r) const
+BOOST_GPU_ENABLED bool interval<T, Policies>::operator== (const number_holder& r) const
 {
   if (!checking::is_empty(low, up)) {
     if (up == r.val && low == r.val) return true;
     else if (up < r.val || low > r.val) return false;
   }
-  throw interval_lib::comparison_error();
+  interval_lib::comparison_error()();
+  return false; // never reached
 }
 
 template<class T, class Policies> inline
-bool interval<T, Policies>::operator!= (const number_holder& r) const
+BOOST_GPU_ENABLED bool interval<T, Policies>::operator!= (const number_holder& r) const
 {
   if (!checking::is_empty(low, up)) {
     if (up < r.val || low > r.val) return true;
     else if (up == r.val && low == r.val) return false;
   }
-  throw interval_lib::comparison_error();
+  interval_lib::comparison_error()();
+  return false; // never reached
 }
 
 } // namespace numeric

--- a/include/boost/numeric/interval/limits.hpp
+++ b/include/boost/numeric/interval/limits.hpp
@@ -26,18 +26,18 @@ private:
   typedef boost::numeric::interval<T, Policies> I;
   typedef numeric_limits<T> bl;
 public:
-  static I min BOOST_PREVENT_MACRO_SUBSTITUTION () BOOST_NOEXCEPT_OR_NOTHROW { return I((bl::min)(), (bl::min)()); }
-  static I max BOOST_PREVENT_MACRO_SUBSTITUTION () BOOST_NOEXCEPT_OR_NOTHROW { return I((bl::max)(), (bl::max)()); }
-  static I epsilon() BOOST_NOEXCEPT_OR_NOTHROW { return I(bl::epsilon(), bl::epsilon()); }
+  static BOOST_GPU_ENABLED I min BOOST_PREVENT_MACRO_SUBSTITUTION () BOOST_NOEXCEPT_OR_NOTHROW { return I((bl::min)(), (bl::min)()); }
+  static BOOST_GPU_ENABLED I max BOOST_PREVENT_MACRO_SUBSTITUTION () BOOST_NOEXCEPT_OR_NOTHROW { return I((bl::max)(), (bl::max)()); }
+  static BOOST_GPU_ENABLED I epsilon() BOOST_NOEXCEPT_OR_NOTHROW { return I(bl::epsilon(), bl::epsilon()); }
 
   BOOST_STATIC_CONSTANT(float_round_style, round_style = round_indeterminate);
   BOOST_STATIC_CONSTANT(bool, is_iec559 = false);
 
-  static I infinity () BOOST_NOEXCEPT_OR_NOTHROW { return I::whole(); }
-  static I quiet_NaN() BOOST_NOEXCEPT_OR_NOTHROW { return I::empty(); }
-  static I signaling_NaN() BOOST_NOEXCEPT_OR_NOTHROW
+  static BOOST_GPU_ENABLED I infinity () BOOST_NOEXCEPT_OR_NOTHROW { return I::whole(); }
+  static BOOST_GPU_ENABLED I quiet_NaN() BOOST_NOEXCEPT_OR_NOTHROW { return I::empty(); }
+  static BOOST_GPU_ENABLED I signaling_NaN() BOOST_NOEXCEPT_OR_NOTHROW
   { return I(bl::signaling_NaN(), bl::signaling_Nan()); }
-  static I denorm_min() BOOST_NOEXCEPT_OR_NOTHROW
+  static BOOST_GPU_ENABLED I denorm_min() BOOST_NOEXCEPT_OR_NOTHROW
   { return I(bl::denorm_min(), bl::denorm_min()); }
 private:
   static I round_error();    // hide this on purpose, not yet implemented

--- a/include/boost/numeric/interval/rounded_arith.hpp
+++ b/include/boost/numeric/interval/rounded_arith.hpp
@@ -25,25 +25,27 @@ namespace interval_lib {
 
 template<class T, class Rounding>
 struct rounded_arith_exact: Rounding {
-  void init() { }
-  template<class U> T conv_down(U const &v) { return v; }
-  template<class U> T conv_up  (U const &v) { return v; }
-  T add_down (const T& x, const T& y) { return x + y; }
-  T add_up   (const T& x, const T& y) { return x + y; }
-  T sub_down (const T& x, const T& y) { return x - y; }
-  T sub_up   (const T& x, const T& y) { return x - y; }
-  T mul_down (const T& x, const T& y) { return x * y; }
-  T mul_up   (const T& x, const T& y) { return x * y; }
-  T div_down (const T& x, const T& y) { return x / y; }
-  T div_up   (const T& x, const T& y) { return x / y; }
-  T median   (const T& x, const T& y) { return (x + y) / 2; }
-  T sqrt_down(const T& x)
+  BOOST_GPU_ENABLED void init() { }
+  template<class U>
+  BOOST_GPU_ENABLED T conv_down(U const &v) { return v; }
+  template<class U>
+  BOOST_GPU_ENABLED T conv_up  (U const &v) { return v; }
+  BOOST_GPU_ENABLED T add_down (const T& x, const T& y) { return x + y; }
+  BOOST_GPU_ENABLED T add_up   (const T& x, const T& y) { return x + y; }
+  BOOST_GPU_ENABLED T sub_down (const T& x, const T& y) { return x - y; }
+  BOOST_GPU_ENABLED T sub_up   (const T& x, const T& y) { return x - y; }
+  BOOST_GPU_ENABLED T mul_down (const T& x, const T& y) { return x * y; }
+  BOOST_GPU_ENABLED T mul_up   (const T& x, const T& y) { return x * y; }
+  BOOST_GPU_ENABLED T div_down (const T& x, const T& y) { return x / y; }
+  BOOST_GPU_ENABLED T div_up   (const T& x, const T& y) { return x / y; }
+  BOOST_GPU_ENABLED T median   (const T& x, const T& y) { return (x + y) / 2; }
+  BOOST_GPU_ENABLED T sqrt_down(const T& x)
   { BOOST_NUMERIC_INTERVAL_using_math(sqrt); return sqrt(x); }
-  T sqrt_up  (const T& x)
+  BOOST_GPU_ENABLED T sqrt_up  (const T& x)
   { BOOST_NUMERIC_INTERVAL_using_math(sqrt); return sqrt(x); }
-  T int_down (const T& x)
+  BOOST_GPU_ENABLED T int_down (const T& x)
   { BOOST_NUMERIC_INTERVAL_using_math(floor); return floor(x); }
-  T int_up   (const T& x)
+  BOOST_GPU_ENABLED T int_up   (const T& x)
   { BOOST_NUMERIC_INTERVAL_using_math(ceil); return ceil(x); }
 };
 

--- a/include/boost/numeric/interval/rounded_transc.hpp
+++ b/include/boost/numeric/interval/rounded_transc.hpp
@@ -22,8 +22,8 @@ template<class T, class Rounding>
 struct rounded_transc_exact: Rounding
 {
 # define BOOST_NUMERIC_INTERVAL_new_func(f) \
-    T f##_down(const T& x) { BOOST_NUMERIC_INTERVAL_using_math(f); return f(x); } \
-    T f##_up  (const T& x) { BOOST_NUMERIC_INTERVAL_using_math(f); return f(x); }
+    BOOST_GPU_ENABLED T f##_down(const T& x) { BOOST_NUMERIC_INTERVAL_using_math(f); return f(x); } \
+    BOOST_GPU_ENABLED T f##_up  (const T& x) { BOOST_NUMERIC_INTERVAL_using_math(f); return f(x); }
   BOOST_NUMERIC_INTERVAL_new_func(exp)
   BOOST_NUMERIC_INTERVAL_new_func(log)
   BOOST_NUMERIC_INTERVAL_new_func(sin)
@@ -37,8 +37,8 @@ struct rounded_transc_exact: Rounding
   BOOST_NUMERIC_INTERVAL_new_func(tanh)
 # undef BOOST_NUMERIC_INTERVAL_new_func
 # define BOOST_NUMERIC_INTERVAL_new_func(f) \
-    T f##_down(const T& x) { BOOST_NUMERIC_INTERVAL_using_ahyp(f); return f(x); } \
-    T f##_up  (const T& x) { BOOST_NUMERIC_INTERVAL_using_ahyp(f); return f(x); }
+    BOOST_GPU_ENABLED T f##_down(const T& x) { BOOST_NUMERIC_INTERVAL_using_ahyp(f); return f(x); } \
+    BOOST_GPU_ENABLED T f##_up  (const T& x) { BOOST_NUMERIC_INTERVAL_using_ahyp(f); return f(x); }
   BOOST_NUMERIC_INTERVAL_new_func(asinh)
   BOOST_NUMERIC_INTERVAL_new_func(acosh)
   BOOST_NUMERIC_INTERVAL_new_func(atanh)

--- a/include/boost/numeric/interval/rounding.hpp
+++ b/include/boost/numeric/interval/rounding.hpp
@@ -22,13 +22,13 @@ template<class T>
 struct rounding_control
 {
   typedef int rounding_mode;
-  static void get_rounding_mode(rounding_mode&) {}
-  static void set_rounding_mode(rounding_mode)  {}
-  static void upward()     {}
-  static void downward()   {}
-  static void to_nearest() {}
-  static const T& to_int(const T& x)         { return x; }
-  static const T& force_rounding(const T& x) { return x; }
+  static BOOST_GPU_ENABLED void get_rounding_mode(rounding_mode&) {}
+  static BOOST_GPU_ENABLED void set_rounding_mode(rounding_mode)  {}
+  static BOOST_GPU_ENABLED void upward()     {}
+  static BOOST_GPU_ENABLED void downward()   {}
+  static BOOST_GPU_ENABLED void to_nearest() {}
+  static BOOST_GPU_ENABLED const T& to_int(const T& x)         { return x; }
+  static BOOST_GPU_ENABLED const T& force_rounding(const T& x) { return x; }
 };
 
 /*

--- a/include/boost/numeric/interval/transc.hpp
+++ b/include/boost/numeric/interval/transc.hpp
@@ -25,7 +25,7 @@ namespace boost {
 namespace numeric {
 
 template<class T, class Policies> inline
-interval<T, Policies> exp(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> exp(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x))
@@ -35,7 +35,7 @@ interval<T, Policies> exp(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> log(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> log(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x) ||
@@ -49,7 +49,7 @@ interval<T, Policies> log(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> cos(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> cos(const interval<T, Policies>& x)
 {
   if (interval_lib::detail::test_input(x))
     return interval<T, Policies>::empty();
@@ -78,7 +78,7 @@ interval<T, Policies> cos(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> sin(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> sin(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x))
@@ -91,7 +91,7 @@ interval<T, Policies> sin(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> tan(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> tan(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x))
@@ -111,7 +111,7 @@ interval<T, Policies> tan(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> asin(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> asin(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x)
@@ -128,7 +128,7 @@ interval<T, Policies> asin(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> acos(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> acos(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x)
@@ -145,7 +145,7 @@ interval<T, Policies> acos(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> atan(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> atan(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x))
@@ -155,7 +155,7 @@ interval<T, Policies> atan(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> sinh(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> sinh(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x))
@@ -165,7 +165,7 @@ interval<T, Policies> sinh(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> cosh(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> cosh(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x))
@@ -180,7 +180,7 @@ interval<T, Policies> cosh(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> tanh(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> tanh(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x))
@@ -190,7 +190,7 @@ interval<T, Policies> tanh(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> asinh(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> asinh(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x))
@@ -200,7 +200,7 @@ interval<T, Policies> asinh(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> acosh(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> acosh(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x) || x.upper() < static_cast<T>(1))
@@ -211,7 +211,7 @@ interval<T, Policies> acosh(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> atanh(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED interval<T, Policies> atanh(const interval<T, Policies>& x)
 {
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x)

--- a/include/boost/numeric/interval/utility.hpp
+++ b/include/boost/numeric/interval/utility.hpp
@@ -13,7 +13,6 @@
 
 #include <boost/numeric/interval/utility_fwd.hpp>
 #include <boost/numeric/interval/detail/test_input.hpp>
-#include <boost/numeric/interval/detail/bugs.hpp>
 #include <algorithm>
 #include <utility>
 
@@ -29,19 +28,19 @@ namespace numeric {
  */
 
 template<class T, class Policies> inline
-const T& lower(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED const T& lower(const interval<T, Policies>& x)
 {
   return x.lower();
 }
 
 template<class T, class Policies> inline
-const T& upper(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED const T& upper(const interval<T, Policies>& x)
 {
   return x.upper();
 }
 
 template<class T, class Policies> inline
-T checked_lower(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED T checked_lower(const interval<T, Policies>& x)
 {
   if (empty(x)) {
     typedef typename Policies::checking checking;
@@ -51,7 +50,7 @@ T checked_lower(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-T checked_upper(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED T checked_upper(const interval<T, Policies>& x)
 {
   if (empty(x)) {
     typedef typename Policies::checking checking;
@@ -61,7 +60,7 @@ T checked_upper(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-T width(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED T width(const interval<T, Policies>& x)
 {
   if (interval_lib::detail::test_input(x)) return static_cast<T>(0);
   typename Policies::rounding rnd;
@@ -69,7 +68,7 @@ T width(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-T median(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED T median(const interval<T, Policies>& x)
 {
   if (interval_lib::detail::test_input(x)) {
     typedef typename Policies::checking checking;
@@ -80,7 +79,7 @@ T median(const interval<T, Policies>& x)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> widen(const interval<T, Policies>& x, const T& v)
+BOOST_GPU_ENABLED interval<T, Policies> widen(const interval<T, Policies>& x, const T& v)
 {
   if (interval_lib::detail::test_input(x))
     return interval<T, Policies>::empty();
@@ -94,34 +93,34 @@ interval<T, Policies> widen(const interval<T, Policies>& x, const T& v)
  */
 
 template<class T, class Policies> inline
-bool empty(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED bool empty(const interval<T, Policies>& x)
 {
   return interval_lib::detail::test_input(x);
 }
 
 template<class T, class Policies> inline
-bool zero_in(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED bool zero_in(const interval<T, Policies>& x)
 {
   if (interval_lib::detail::test_input(x)) return false;
   return (!interval_lib::user::is_pos(x.lower())) &&
          (!interval_lib::user::is_neg(x.upper()));
 }
 
-template<class T, class Policies> inline
+/* template<class T, class Policies> inline
 bool in_zero(const interval<T, Policies>& x) // DEPRECATED
 {
   return zero_in<T, Policies>(x);
-}
+} */
 
 template<class T, class Policies> inline
-bool in(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED bool in(const T& x, const interval<T, Policies>& y)
 {
   if (interval_lib::detail::test_input(x, y)) return false;
   return y.lower() <= x && x <= y.upper();
 }
 
 template<class T, class Policies> inline
-bool subset(const interval<T, Policies>& x,
+BOOST_GPU_ENABLED bool subset(const interval<T, Policies>& x,
             const interval<T, Policies>& y)
 {
   if (empty(x)) return true;
@@ -129,7 +128,7 @@ bool subset(const interval<T, Policies>& x,
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool proper_subset(const interval<T, Policies1>& x,
+BOOST_GPU_ENABLED bool proper_subset(const interval<T, Policies1>& x,
                    const interval<T, Policies2>& y)
 {
   if (empty(y)) return false;
@@ -139,7 +138,7 @@ bool proper_subset(const interval<T, Policies1>& x,
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool overlap(const interval<T, Policies1>& x,
+BOOST_GPU_ENABLED bool overlap(const interval<T, Policies1>& x,
              const interval<T, Policies2>& y)
 {
   if (interval_lib::detail::test_input(x, y)) return false;
@@ -148,21 +147,21 @@ bool overlap(const interval<T, Policies1>& x,
 }
 
 template<class T, class Policies> inline
-bool singleton(const interval<T, Policies>& x)
+BOOST_GPU_ENABLED bool singleton(const interval<T, Policies>& x)
 {
  return !empty(x) && x.lower() == x.upper();
 }
 
 template<class T, class Policies1, class Policies2> inline
-bool equal(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
+BOOST_GPU_ENABLED bool equal(const interval<T, Policies1>& x, const interval<T, Policies2>& y)
 {
   if (empty(x)) return empty(y);
   return !empty(y) && x.lower() == y.lower() && x.upper() == y.upper();
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> intersect(const interval<T, Policies>& x,
-                                const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> intersect(const interval<T, Policies>& x,
+                                                  const interval<T, Policies>& y)
 {
   BOOST_USING_STD_MIN();
   BOOST_USING_STD_MAX();
@@ -175,7 +174,7 @@ interval<T, Policies> intersect(const interval<T, Policies>& x,
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> hull(const interval<T, Policies>& x,
+BOOST_GPU_ENABLED interval<T, Policies> hull(const interval<T, Policies>& x,
                            const interval<T, Policies>& y)
 {
   BOOST_USING_STD_MIN();
@@ -192,7 +191,7 @@ interval<T, Policies> hull(const interval<T, Policies>& x,
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> hull(const interval<T, Policies>& x, const T& y)
+BOOST_GPU_ENABLED interval<T, Policies> hull(const interval<T, Policies>& x, const T& y)
 {
   BOOST_USING_STD_MIN();
   BOOST_USING_STD_MAX();
@@ -208,7 +207,7 @@ interval<T, Policies> hull(const interval<T, Policies>& x, const T& y)
 }
 
 template<class T, class Policies> inline
-interval<T, Policies> hull(const T& x, const interval<T, Policies>& y)
+BOOST_GPU_ENABLED interval<T, Policies> hull(const T& x, const interval<T, Policies>& y)
 {
   BOOST_USING_STD_MIN();
   BOOST_USING_STD_MAX();
@@ -224,20 +223,21 @@ interval<T, Policies> hull(const T& x, const interval<T, Policies>& y)
 }
 
 template<class T> inline
-interval<T> hull(const T& x, const T& y)
+BOOST_GPU_ENABLED interval<T> hull(const T& x, const T& y)
 {
   return interval<T>::hull(x, y);
 }
 
 template<class T, class Policies> inline
-std::pair<interval<T, Policies>, interval<T, Policies> >
+BOOST_GPU_ENABLED BOOST_NUMERIC_INTERVAL_std(pair)<interval<T,Policies>,interval<T,Policies> >
 bisect(const interval<T, Policies>& x)
 {
+  BOOST_NUMERIC_INTERVAL_using_std(pair);
   typedef interval<T, Policies> I;
   if (interval_lib::detail::test_input(x))
-    return std::pair<I,I>(I::empty(), I::empty());
+    return pair<I,I>(I::empty(), I::empty());
   const T m = median(x);
-  return std::pair<I,I>(I(x.lower(), m, true), I(m, x.upper(), true));
+  return pair<I,I>(I(x.lower(), m, true), I(m, x.upper(), true));
 }
 
 /*

--- a/include/boost/numeric/interval/utility_fwd.hpp
+++ b/include/boost/numeric/interval/utility_fwd.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/config.hpp>
 #include <boost/numeric/interval/detail/interval_prototype.hpp>
+#include <boost/numeric/interval/detail/bugs.hpp>
 #include <utility>
 
 /*
@@ -25,94 +26,94 @@ namespace boost { namespace numeric {
      */
 
     template<class T, class Policies>
-    const T& lower(const interval<T,Policies>& x);
+    BOOST_GPU_ENABLED const T& lower(const interval<T,Policies>& x);
 
     template<class T, class Policies>
-    const T& upper(const interval<T,Policies>& x);
+    BOOST_GPU_ENABLED const T& upper(const interval<T,Policies>& x);
 
     template<class T, class Policies>
-    T checked_lower(const interval<T,Policies>& x);
+    BOOST_GPU_ENABLED T checked_lower(const interval<T,Policies>& x);
 
     template<class T, class Policies>
-    T width(const interval<T,Policies>& x);
+    BOOST_GPU_ENABLED T width(const interval<T,Policies>& x);
 
     template<class T, class Policies>
-    T median(const interval<T,Policies>& x);
+    BOOST_GPU_ENABLED T median(const interval<T,Policies>& x);
 
     template<class T, class Policies>
-    interval<T,Policies> widen(const interval<T,Policies>& x, const T& v);
+    BOOST_GPU_ENABLED interval<T,Policies> widen(const interval<T,Policies>& x, const T& v);
 
     /*
      * Set-like operations
      */
 
     template <class T, class Policies>
-    bool empty(const interval<T,Policies>& x);
+    BOOST_GPU_ENABLED bool empty(const interval<T,Policies>& x);
 
     template <class T, class Policies>
-    bool zero_in(const interval<T,Policies>& x);
+    BOOST_GPU_ENABLED bool zero_in(const interval<T,Policies>& x);
 
     template <class T, class Policies>
-    bool in_zero(const interval<T,Policies>& x);  // DEPRECATED
+    BOOST_GPU_ENABLED bool in_zero(const interval<T,Policies>& x);  // DEPRECATED
 
     template <class T, class Policies>
-    bool in(const T& x, const interval<T,Policies>& y);
+    BOOST_GPU_ENABLED bool in(const T& x, const interval<T,Policies>& y);
 
     template <class T, class Policies>
-    bool
+    BOOST_GPU_ENABLED bool
         subset(
             const interval<T,Policies>& x
           , const interval<T,Policies>& y
         );
 
     template <class T, class Policies1, class Policies2>
-    bool
+    BOOST_GPU_ENABLED bool
         proper_subset(
             const interval<T,Policies1>& x
           , const interval<T,Policies2>& y
         );
 
     template <class T, class Policies1, class Policies2>
-    bool
+    BOOST_GPU_ENABLED bool
         overlap(
             const interval<T,Policies1>& x
           , const interval<T,Policies2>& y
         );
 
     template <class T, class Policies>
-    bool singleton(const interval<T, Policies>& x);
+    BOOST_GPU_ENABLED bool singleton(const interval<T, Policies>& x);
 
     template <class T, class Policies1, class Policies2>
-    bool
+    BOOST_GPU_ENABLED bool
         equal(
             const interval<T,Policies1>& x
           , const interval<T,Policies2>& y
         );
 
     template <class T, class Policies>
-    interval<T, Policies>
+    BOOST_GPU_ENABLED interval<T, Policies>
         intersect(
             const interval<T,Policies>& x
           , const interval<T,Policies>& y
         );
 
     template <class T, class Policies>
-    interval<T, Policies>
+    BOOST_GPU_ENABLED interval<T, Policies>
         hull(const interval<T,Policies>& x, const interval<T,Policies>& y);
 
     template <class T, class Policies>
-    interval<T, Policies>
+    BOOST_GPU_ENABLED interval<T, Policies>
         hull(const interval<T,Policies>& x, const T& y);
 
     template <class T, class Policies>
-    interval<T, Policies>
+    BOOST_GPU_ENABLED interval<T, Policies>
         hull(const T& x, const interval<T,Policies>& y);
 
     template <class T>
-    interval<T> hull(const T& x, const T& y);
-
+    BOOST_GPU_ENABLED interval<T> hull(const T& x, const T& y);
+    
     template <class T, class Policies>
-    std::pair<interval<T,Policies>,interval<T,Policies> >
+    BOOST_GPU_ENABLED BOOST_NUMERIC_INTERVAL_std(pair)<interval<T,Policies>,interval<T,Policies> >
         bisect(const interval<T,Policies>& x);
 
     /*
@@ -120,48 +121,48 @@ namespace boost { namespace numeric {
      */
 
     template <class T, class Policies>
-    T norm(const interval<T,Policies>& x);
+    BOOST_GPU_ENABLED T norm(const interval<T,Policies>& x);
 
     template <class T, class Policies>
-    interval<T,Policies> abs(const interval<T,Policies>& x);
+    BOOST_GPU_ENABLED interval<T,Policies> abs(const interval<T,Policies>& x);
 
     template <class T, class Policies>
-    interval<T,Policies>
+    BOOST_GPU_ENABLED interval<T,Policies>
         max BOOST_PREVENT_MACRO_SUBSTITUTION (
             const interval<T,Policies>& x
           , const interval<T,Policies>& y
         );
 
     template <class T, class Policies>
-    interval<T,Policies>
+    BOOST_GPU_ENABLED interval<T,Policies>
         max BOOST_PREVENT_MACRO_SUBSTITUTION (
             const interval<T,Policies>& x
           , const T& y
         );
 
     template <class T, class Policies>
-    interval<T,Policies>
+    BOOST_GPU_ENABLED interval<T,Policies>
         max BOOST_PREVENT_MACRO_SUBSTITUTION (
             const T& x
           , const interval<T,Policies>& y
         );
 
     template <class T, class Policies>
-    interval<T,Policies>
+    BOOST_GPU_ENABLED interval<T,Policies>
         min BOOST_PREVENT_MACRO_SUBSTITUTION (
             const interval<T,Policies>& x
           , const interval<T,Policies>& y
         );
 
     template <class T, class Policies>
-    interval<T,Policies>
+    BOOST_GPU_ENABLED interval<T,Policies>
         min BOOST_PREVENT_MACRO_SUBSTITUTION (
             const interval<T,Policies>& x
           , const T& y
         );
 
     template <class T, class Policies>
-    interval<T,Policies>
+    BOOST_GPU_ENABLED interval<T,Policies>
         min BOOST_PREVENT_MACRO_SUBSTITUTION (
             const T& x
           , const interval<T,Policies>& y


### PR DESCRIPTION
The goal of this patch is to provide support for CUDA-compatible GPUs. This is achieved by introducing a new rounding type that does not switch modes because CUDA provides arithmetic operations as explicitly rounded functions.

This is still a work in progress.