### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -22,7 +22,6 @@ logic
 
 core
 preprocessor
-static_assert
 type_traits
 assert
 throw_exception


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.